### PR TITLE
pylint: allow single character variable names

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -114,7 +114,7 @@ function-rgx=[a-z_][a-z0-9_]{2,30}$
 function-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct variable names
-variable-rgx=[a-z_][a-z0-9_]{2,30}$
+variable-rgx=[a-z_][a-z0-9_]{0,30}$
 
 # Naming hint for variable names
 variable-name-hint=[a-z_][a-z0-9_]{2,30}$


### PR DESCRIPTION
pylint by default requires variable names to be three or more characters. This reduces that requirement to one character.