### PR TITLE
reorganize GeometricProgram.solve(); fixes #526

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -60,7 +60,7 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 #disable=import-star-module-level,old-octal-literal,oct-method,print-statement,unpacking-in-except,parameter-unpacking,backtick,old-raise-syntax,old-ne-operator,long-suffix,dict-view-method,dict-iter-method,metaclass-assignment,next-method-called,raising-string,indexing-exception,raw_input-builtin,long-builtin,file-builtin,execfile-builtin,coerce-builtin,cmp-builtin,buffer-builtin,basestring-builtin,apply-builtin,filter-builtin-not-iterating,using-cmp-argument,useless-suppression,range-builtin-not-iterating,suppressed-message,no-absolute-import,old-division,cmp-method,reload-builtin,zip-builtin-not-iterating,intern-builtin,unichr-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,input-builtin,round-builtin,hex-method,nonzero-method,map-builtin-not-iterating
-disable=superfluous-parens
+disable=superfluous-parens,locally-disabled
 
 [REPORTS]
 

--- a/gpkit/__init__.py
+++ b/gpkit/__init__.py
@@ -158,4 +158,4 @@ def load_settings(path=SETTINGS_PATH):
     settings_["default_solver"] = settings_["installed_solvers"][0]
     settings_["latex_modelname"] = True
     return settings_
-settings = load_settings()
+settings = load_settings()  # pylint: disable=invalid-name

--- a/gpkit/__init__.py
+++ b/gpkit/__init__.py
@@ -141,6 +141,7 @@ if units:
 
 # Load settings
 def load_settings(path=SETTINGS_PATH):
+    """Load the settings file at SETTINGS_PATH; return settings dict"""
     try:
         with open(path) as settingsfile:
             lines = [line[:-1].split(" : ") for line in settingsfile
@@ -154,6 +155,7 @@ def load_settings(path=SETTINGS_PATH):
     except IOError:
         print("Could not load settings file.")
         settings_ = {"installed_solvers": [""]}
+    settings_["default_solver"] = settings_["installed_solvers"][0]
+    settings_["latex_modelname"] = True
     return settings_
 settings = load_settings()
-settings["latex_modelname"] = True


### PR DESCRIPTION
 - avoids calling `np.exp` for non-optimal solutions (which resulted in a `RuntimeWarning` in #526)
 - still allows user to create the results dict for non-optimal models as described in error message edited in this PR