### PR TITLE
assorted pylint tweaks

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -169,7 +169,7 @@ method-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
-no-docstring-rgx=^_
+no-docstring-rgx=^_|^t_
 
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.
@@ -185,7 +185,7 @@ max-nested-blocks=5
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=80
 
 # Regexp for a line that is allowed to be longer than the limit.
 ignore-long-lines=^\s*(# )?<?https?://\S+>?$
@@ -332,7 +332,7 @@ max-locals=15
 max-returns=6
 
 # Maximum number of branch for function / method body
-max-branches=12
+max-branches=15
 
 # Maximum number of statements in function / method body
 max-statements=50


### PR DESCRIPTION
 - increase max branches from 12 to 15
 - line length 80 char
 - docstrings not required for unit test methods