### PR TITLE
CI status on README; install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,8 @@ Supported solvers are
 [mosek](http://mosek.com)
 and [cvxopt](http://cvxopt.org/).
 
-[![Build Status](https://acdl.mit.edu/csi/buildStatus/icon?job=gpkit_Push)](https://acdl.mit.edu/csi/job/gpkit_Push/)
+[![Build Status](https://acdl.mit.edu/csi/buildStatus/icon?job=gpkit_Push)](https://acdl.mit.edu/csi/job/gpkit_Push/) Unit tests
+
+[![Build Status](https://acdl.mit.edu/csi/buildStatus/icon?job=gpkit_Install)](https://acdl.mit.edu/csi/job/gpkit_Install/) pip install
+
+[![Build Status](https://acdl.mit.edu/csi/buildStatus/icon?job=gpkit_Push_Depends)](https://acdl.mit.edu/csi/job/gpkit_Push_Depends/) Dependencies

--- a/docs/source/citinggpkit.rst
+++ b/docs/source/citinggpkit.rst
@@ -5,7 +5,7 @@ If you use GPkit, please cite it with the following bibtex::
 
     @Misc{gpkit,
           author={Edward Burnell and Warren Hoburg},
-          title={GPkit},
+          title={GPkit software for geometric programming},
           howpublished={\url{https://github.com/hoburg/gpkit}},
           year={2015},
           note={Version 0.3.4}

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -107,9 +107,8 @@ You may need to rebuild GPkit if any of the following occur:
   - You see a ``Could not load settings file.`` message
   - You see a ``Could not load MOSEK library: ImportError('$HOME/.gpkit/expopt.so not found.`` error.
 To rebuild GPkit, do the following:
-  - Start ``ipython``
-  - Run the command ``import os; os.chdir(os.path.dirname(gpkit.__file__)); del gpkit; import build; build.build_gpkit()``
-  - Exit ipython
+  - Run ``pip uninstall gpkit``
+  - Run ``pip install --no-cache-dir --no-deps gpkit``
   - Run ``python -c "import gpkit.tests; gpkit.tests.run()"``
   - If any tests fail, email ``gpkit@mit.edu``.
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -39,19 +39,6 @@ Mac OS X
   - Run ``pip install ipywidgets`` for interactive control of models (recommended)
   - Run ``python -c "import gpkit.tests; gpkit.tests.run()"``
 
-4. Debug Installation
-+++++++++++++++++++++
-If your installation is not working, try the following:
-  - Start iPython. Commands below that start with ``>>>`` should be run in iPython
-  - If ``>>> import gpkit`` prints "Could not load settings file.", then:
-      - ``>>> import os; os.chdir(os.path.dirname(gpkit.__file__))``
-      - ``>>> del gpkit``
-      - ``>>> import build; build.build_gpkit()``
-      - Exit iPython
-      - Run ``python -c "import gpkit.tests; gpkit.tests.run()"``
-      - If any tests fail, email ``gpkit@mit.edu``.
-
-
 
 Linux
 =====
@@ -78,19 +65,6 @@ Linux
   - Run ``pip install pint`` for units support (recommended)
   - Run ``pip install ipywidgets`` for interactive control of models (recommended)
   - Run ``python -c "import gpkit.tests; gpkit.tests.run()"``
-
-4. Debug Installation
-+++++++++++++++++++++
-If your installation is not working, try the following:
-  - Start iPython. Commands below that start with ``>>>`` should be run in iPython
-  - If ``>>> import gpkit`` prints "Could not load settings file.", then:
-      - ``>>> import os; os.chdir(os.path.dirname(gpkit.__file__))``
-      - ``>>> del gpkit``
-      - ``>>> import build; build.build_gpkit()``
-      - Exit iPython
-      - Run ``python -c "import gpkit.tests; gpkit.tests.run()"``
-      - If any tests fail, email ``gpkit@mit.edu``.
-
 
 
 Windows
@@ -125,23 +99,25 @@ Windows
   - Run ``pip install ipywidgets`` for interactive control of models (recommended)
 
 
-4. Debug Installation
-+++++++++++++++++++++
-If your installation is not working, try the following:
-  - Start iPython. Commands below that start with ``>>>`` should be run in iPython
-  - If ``>>> import gpkit`` prints "Could not load settings file.", then:
-      - ``>>> import os; os.chdir(os.path.dirname(gpkit.__file__))``
-      - ``>>> del gpkit``
-      - ``>>> import build; build.build_gpkit()``
-      - Exit iPython
-      - Run ``python -c "import gpkit.tests; gpkit.tests.run()"``
-      - If any tests fail, email ``gpkit@mit.edu``.
+Debugging installation
+======================
+You may need to rebuild GPkit if any of the following occur:
+  - You install a new solver (mosek or cvxopt) after installing GPkit
+  - You delete the ``.gpkit`` folder from your home directory
+  - You see a ``Could not load settings file.`` message
+  - You see a ``Could not load MOSEK library: ImportError('$HOME/.gpkit/expopt.so not found.`` error.
+To rebuild GPkit, do the following:
+  - Start ``ipython``
+  - Run the command ``import os; os.chdir(os.path.dirname(gpkit.__file__)); del gpkit; import build; build.build_gpkit()``
+  - Exit ipython
+  - Run ``python -c "import gpkit.tests; gpkit.tests.run()"``
+  - If any tests fail, email ``gpkit@mit.edu``.
 
 
 Updating GPkit between releases
 ===============================
 
-Active developers may wish to install the `latest GPkit <http://github.com/hoburg/gpkit>` directly from the source code on Github. To do so,
+Active developers may wish to install the `latest GPkit <http://github.com/hoburg/gpkit>`_ directly from the source code on Github. To do so,
 
   - Run ``pip uninstall gpkit`` to uninstall your existing GPkit.
   - Run ``git clone https://github.com/hoburg/gpkit.git`` to clone the GPkit repository, or ``cd gpkit; git pull origin master; cd ..`` to update your existing repository.

--- a/gpkit/tests/t_solution_array.py
+++ b/gpkit/tests/t_solution_array.py
@@ -9,6 +9,7 @@ from gpkit.varkey import VarKey
 
 
 class TestSolutionArray(unittest.TestCase):
+    """Unit tests for the SolutionArray class"""
 
     def test_call(self):
         A = Variable('A', '-', 'Test Variable')
@@ -49,7 +50,7 @@ class TestSolutionArray(unittest.TestCase):
         sol = prob.solve(verbosity=0)
         t1 = time.time()
         _ = sol(z1)
-        self.assertTrue(time.time() - t1 <= 0.05)
+        self.assertLess(time.time() - t1, 0.05)
 
     def test_subinto_sens(self):
         Nsweep = 20


### PR DESCRIPTION
Final cleanup to close out #509 

 - show Jenkins status for all three machines on README
 - eliminate duplicate debugging info from install instructions
 - update debugging info with other potential failure modes as suggested by @galbramc