### PR TITLE
Added "develop" to trigger a build in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import sys
 
 # custom build script
-if sys.argv[1] in ["build", "install"]:
+if sys.argv[1] in ["build", "install", "develop"]:
     from gpkit.build import build_gpkit
     build_gpkit()
 


### PR DESCRIPTION
Currently "pip install -e" does not cause gpkit to rebuild. I think the safest thing to do is always rebuild, especially since your documentation lists this as a method for staying up to date.