### PR TITLE
profile refactor

### DIFF
--- a/gpkit/constraints/costed.py
+++ b/gpkit/constraints/costed.py
@@ -30,15 +30,15 @@ class CostedConstraintSet(ConstraintSet):
             else:
                 return variables
 
-    def sub(self, subs, value=None):
+    def subinplace(self, subs, value=None):
         "Substitutes in place."
         self.cost = self.cost.sub(subs, value)
-        return ConstraintSet.sub(self, subs, value)
+        ConstraintSet.subinplace(self, subs, value)
 
     @property
     def varkeys(self):
         "return all Varkeys present in this ConstraintSet"
-        return ConstraintSet._varkeys(self, self.cost.varkeys)
+        return ConstraintSet._varkeys(self, self.cost.varlocs)
 
     def rootconstr_str(self, excluded=None):
         "The appearance of a ConstraintSet in addition to its contents"

--- a/gpkit/constraints/link.py
+++ b/gpkit/constraints/link.py
@@ -64,7 +64,7 @@ class LinkConstraint(ConstraintSet):
             self.linked.update(dict(zip(vks, len(vks)*[newvk])))
             self.reverselinks[newvk] = vks
         with SignomialsEnabled():  # since we're just substituting varkeys.
-            self.sub(self.linked)
+            self.subinplace(self.linked)
 
     def process_result(self, result):
         for k in ["constants", "variables", "freevariables", "sensitivities"]:

--- a/gpkit/constraints/model.py
+++ b/gpkit/constraints/model.py
@@ -7,6 +7,7 @@ from .prog_factories import _progify_fctry, _solve_fctry
 from ..geometric_program import GeometricProgram
 from .signomial_program import SignomialProgram
 from .link import LinkConstraint
+from ..keydict import KeyDict
 from .. import SignomialsEnabled
 
 
@@ -73,7 +74,7 @@ class Model(CostedConstraintSet):
         return Model(cost, [lc], lc.substitutions)
 
     def _add_modelname_tovars(self, name, num):
-        add_model_subs = {}
+        add_model_subs = KeyDict()
         for vk in self.varkeys:
             descr = dict(vk.descr)
             descr["models"] = descr.pop("models", []) + [name]

--- a/gpkit/constraints/model.py
+++ b/gpkit/constraints/model.py
@@ -86,7 +86,7 @@ class Model(CostedConstraintSet):
                 del self.substitutions[vk]
         self.substitutions.regen_keymap()
         with SignomialsEnabled():  # since we're just substituting varkeys.
-            self.sub(add_model_subs)
+            self.subinplace(add_model_subs)
 
     def subconstr_str(self, excluded=None):
         "The collapsed appearance of a ConstraintBase"

--- a/gpkit/constraints/set.py
+++ b/gpkit/constraints/set.py
@@ -121,8 +121,7 @@ class ConstraintSet(list):
         "Returns list of posynomials which must be kept <= 1"
         posylist, self.posymap = [], []
         for constraint in self:
-            constraint.substitutions = KeyDict()
-            constraint.substitutions.update(self.substitutions)
+            constraint.substitutions = KeyDict(self.substitutions)
             posys = constraint.as_posyslt1()
             self.posymap.append(len(posys))
             posylist.extend(posys)

--- a/gpkit/constraints/set.py
+++ b/gpkit/constraints/set.py
@@ -97,11 +97,10 @@ class ConstraintSet(list):
                 for yielded_constraint in subgenerator:
                     yield yielded_constraint
 
-    def sub(self, subs, value=None):
+    def subinplace(self, subs, value=None):
         "Substitutes in place."
-        for i, constraint in enumerate(self):
-            self[i] = constraint.sub(subs, value)
-        return self
+        for constraint in self:
+            constraint.subinplace(subs, value)
 
     @property
     def varkeys(self):

--- a/gpkit/constraints/single_equation.py
+++ b/gpkit/constraints/single_equation.py
@@ -46,10 +46,8 @@ class SingleEquationConstraint(object):
 
     def sub(self, subs, value=None):
         "Returns a substituted version of this constraint."
-        if value:
-            subs = {subs: value}
-        subbed = self.func_opers[self.oper](self.left.sub(subs),
-                                            self.right.sub(subs))
+        subbed = self.func_opers[self.oper](self.left.sub(subs, value),
+                                            self.right.sub(subs, value))
         subbed.substitutions = self.substitutions
         return subbed
 

--- a/gpkit/nomials/data.py
+++ b/gpkit/nomials/data.py
@@ -163,7 +163,7 @@ def simplify_exps_and_cs(exps, cs, return_map=False):
     exps_ = tuple(matches.keys())
     cs_ = list(matches.values())
     if units:
-        cs_ = cs_*units
+        cs_ = Quantity(cs_, units)
     else:
         cs_ = np.array(cs_, dtype='float')
 

--- a/gpkit/nomials/data.py
+++ b/gpkit/nomials/data.py
@@ -34,10 +34,7 @@ class NomialData(object):
                     varlocs[var] = []
                 varlocs[var].append(i)
         self.varlocs = varlocs
-        self.varkeys = KeySet(self.varlocs)  # TODO: don't need a full KeySet
-        self.values = KeyDict({vk: vk.descr["value"] for vk in self.varkeys
-                               if "value" in vk.descr})
-
+        self._varkeys, self._values = None, None
         if isinstance(self.cs, Quantity):
             self.units = Quantity(1, self.cs.units) #pylint: disable=no-member
         else:
@@ -58,6 +55,19 @@ class NomialData(object):
         nd = cls()  # use pass-through version of __init__
         nd.init_from_nomials(nomials)
         return nd
+
+    @property
+    def varkeys(self):
+        if not self._varkeys:
+            self._varkeys = KeySet(self.varlocs)
+        return self._varkeys
+
+    @property
+    def values(self):
+        if not self._values:
+            self._values = KeyDict({k: k.descr["value"] for k in self.varlocs
+                                    if "value" in k.descr})
+        return self._values
 
     def init_from_nomials(self, nomials):
         """Way to initialize from nomials. Calls __init__.

--- a/gpkit/nomials/nomial_math.py
+++ b/gpkit/nomials/nomial_math.py
@@ -118,8 +118,12 @@ class Signomial(Nomial):
             self.exp = self.exps[0]
             self.c = self.cs[0]
 
+    def to(self, arg):
+        "Create new Signomial converted to new units"
+        return Signomial(self.exps, self.cs.to(arg).tolist())
+
     def convert_to(self, arg):
-        "Convert to in the pint units sense"
+        "Convert this signomial to new units"
         self.cs = self.cs.to(arg)
 
     def diff(self, wrt):

--- a/gpkit/nomials/nomial_math.py
+++ b/gpkit/nomials/nomial_math.py
@@ -498,12 +498,6 @@ class PosynomialInequality(ScalarSingleEquationConstraint):
 
         out = []
         for posy in posys:
-            if hasattr(self, "m_gt"):
-                m_gt = self.m_gt.sub(self.substitutions,
-                                     require_positive=False)
-                if m_gt.c == 0:
-                    return []
-
             _, exps, cs, _ = substitution(posy, self.substitutions)
             # remove any cs that are just nans and/or 0s
             nans = np.isnan(cs)

--- a/gpkit/nomials/nomial_math.py
+++ b/gpkit/nomials/nomial_math.py
@@ -452,6 +452,7 @@ class PosynomialInequality(ScalarSingleEquationConstraint):
         self.substitutions = dict(p_lt.values)
         self.substitutions.update(m_gt.values)
         self._unsubbed = None
+        self._gen_unsubbed()
 
     def _gen_unsubbed(self):
         p = self.p_lt / self.m_gt
@@ -478,7 +479,7 @@ class PosynomialInequality(ScalarSingleEquationConstraint):
         self._unsubbed = [p]
 
     def as_posyslt1(self):
-        self._gen_unsubbed()
+        # self._gen_unsubbed()
         posys = self._unsubbed
         if not self.substitutions:
             # just return the pre-generated posynomial representation
@@ -563,6 +564,7 @@ class MonomialEquality(PosynomialInequality):
         self.substitutions = dict(self.left.values)
         self.substitutions.update(self.right.values)
         self._unsubbed = None
+        self._gen_unsubbed()
 
     def _gen_unsubbed(self):
         self._unsubbed = [self.left/self.right, self.right/self.left]
@@ -625,7 +627,7 @@ class SignomialInequality(ScalarSingleEquationConstraint):
         else:
             self.__class__ = PosynomialInequality
             self.__init__(posy, "<=", negy)
-            self._gen_unsubbed()
+            # self._gen_unsubbed()
             return self._unsubbed
 
     def as_gpconstr(self, x0):

--- a/gpkit/nomials/substitution.py
+++ b/gpkit/nomials/substitution.py
@@ -170,7 +170,7 @@ def substitution(nomial, substitutions, val=None):
                                               sub.units.units,
                                               var, var.units.units))
                 if isinstance(sub, VarKey):
-                    exps_[i] += HashVector({sub: x})
+                    exps_[i][sub] = x + exps_[i].get(x, 0)
                     varlocs_[sub].append(i)
                 else:
                     exps_[i] += x*sub.exp

--- a/gpkit/tests/t_constraints.py
+++ b/gpkit/tests/t_constraints.py
@@ -30,8 +30,10 @@ class TestConstraint(unittest.TestCase):
         c2 = 1 >= 5*x + 0.5
         self.assertEqual(type(c1), PosynomialInequality)
         self.assertEqual(type(c2), PosynomialInequality)
-        self.assertEqual(c1.as_posyslt1()[0].cs, c2.as_posyslt1()[0].cs)
-        self.assertEqual(c1.as_posyslt1()[0].exps, c2.as_posyslt1()[0].exps)
+        c1posy, = c1.as_posyslt1()
+        c2posy, = c2.as_posyslt1()
+        self.assertEqual(c1posy.cs, c2posy.cs)
+        self.assertEqual(c1posy.exps, c2posy.exps)
 
     def test_additive_scalar_gt1(self):
         """1 can't be greater than (1 + something positive)"""

--- a/gpkit/tests/t_constraints.py
+++ b/gpkit/tests/t_constraints.py
@@ -39,7 +39,7 @@ class TestConstraint(unittest.TestCase):
 
         def constr():
             """method that should raise a ValueError"""
-            return (1 >= 5*x + 1.1).as_posyslt1()
+            return (1 >= 5*x + 1.1)
         self.assertRaises(ValueError, constr)
 
     def test_init(self):
@@ -101,7 +101,7 @@ class TestMonomialEquality(unittest.TestCase):
 
         def constr():
             """method that should raise a TypeError"""
-            MonomialEquality(x*y, "=", x+y).as_posyslt1()
+            MonomialEquality(x*y, "=", x+y)
         self.assertRaises(TypeError, constr)
 
     def test_str(self):

--- a/gpkit/tests/t_constraints.py
+++ b/gpkit/tests/t_constraints.py
@@ -30,8 +30,8 @@ class TestConstraint(unittest.TestCase):
         c2 = 1 >= 5*x + 0.5
         self.assertEqual(type(c1), PosynomialInequality)
         self.assertEqual(type(c2), PosynomialInequality)
-        self.assertEqual(c1.posylt1_rep.cs, c2.posylt1_rep.cs)
-        self.assertEqual(c1.posylt1_rep.exps, c2.posylt1_rep.exps)
+        self.assertEqual(c1.as_posyslt1()[0].cs, c2.as_posyslt1()[0].cs)
+        self.assertEqual(c1.as_posyslt1()[0].exps, c2.as_posyslt1()[0].exps)
 
     def test_additive_scalar_gt1(self):
         """1 can't be greater than (1 + something positive)"""
@@ -39,7 +39,7 @@ class TestConstraint(unittest.TestCase):
 
         def constr():
             """method that should raise a ValueError"""
-            return (1 >= 5*x + 1.1)
+            return (1 >= 5*x + 1.1).as_posyslt1()
         self.assertRaises(ValueError, constr)
 
     def test_init(self):
@@ -98,8 +98,11 @@ class TestMonomialEquality(unittest.TestCase):
         """Try to initialize a MonomialEquality with non-monomial args"""
         x = Variable('x')
         y = Variable('y')
-        # try to initialize a Posynomial Equality constraint
-        self.assertRaises(TypeError, MonomialEquality, x*y, "=", x + y)
+
+        def constr():
+            """method that should raise a TypeError"""
+            MonomialEquality(x*y, "=", x+y).as_posyslt1()
+        self.assertRaises(TypeError, constr)
 
     def test_str(self):
         "Test that MonomialEquality.__str__ returns a string"

--- a/gpkit/tests/t_nomials.py
+++ b/gpkit/tests/t_nomials.py
@@ -304,8 +304,8 @@ class TestPosynomial(unittest.TestCase):
         x = Monomial('x')
         y = Monomial('y')
         p = x**2 + 2*y*x + y**2
-        self.assertEqual((p <= 1).posylt1_rep, p)
-        self.assertEqual((p <= x).posylt1_rep, p/x)
+        self.assertEqual((p <= 1).as_posyslt1(), [p])
+        self.assertEqual((p <= x).as_posyslt1(), [p/x])
 
     def test_integer_division(self):
         "Make sure division by integer doesn't use Python integer division"

--- a/gpkit/tests/t_sub.py
+++ b/gpkit/tests/t_sub.py
@@ -169,11 +169,11 @@ class TestGPSubs(unittest.TestCase):
                 Model.__init__(self, x, [x >= x_min])
 
         a, b = Above(), Below()
+        concatm = Model(a.cost*b.cost, [a, b])
+        concat_cost = concatm.solve(verbosity=0)["cost"]
         if not isinstance(a["x"].key.units, str):
             self.assertAlmostEqual(a.solve(verbosity=0)["cost"], 0.3333333)
             self.assertAlmostEqual(b.solve(verbosity=0)["cost"], 0.01)
-            concatm = Model(a.cost*b.cost, [a, b])
-            concat_cost = concatm.solve(verbosity=0)["cost"]
             self.assertAlmostEqual(concat_cost, 0.0109361)  # 1 cm/1 yd
         a1, b1 = Above(), Below()
         m = a1.link(b1)

--- a/gpkit/varkey.py
+++ b/gpkit/varkey.py
@@ -55,17 +55,17 @@ class VarKey(object):
                 units = units.replace("-", "dimensionless")
                 self.descr["units"] = Quantity(1.0, units)
             elif isinstance(units, Quantity):
-                self.descr["units"] = Quantity(1.0, units.units)
+                self.descr["units"] = units
             else:
                 raise ValueError("units must be either a string"
                                  " or a Quantity from gpkit.units.")
         self._hashvalue = hash(str(self))
         self.key = self
-        self.keys = self.allstrs
-        self.keys.add(self)
+        self.keys = set([self, self.name, str(self), self.latex(),
+                         self.str_without("models")])
         if "idx" in self.descr:
             self.keys.add(veckeyed(self))
-        self.descr["unitstr"] = self.make_unitstr()
+        self.descr["unitstr"] = self.make_unitstr()  # annoyingly slow
 
     def __repr__(self):
         return self.str_without()
@@ -83,12 +83,6 @@ class VarKey(object):
         if self.shape and not self.idx:
             string = "\\vec{%s}" % string  # add vector arrow for veckeys
         return string
-
-    @property
-    def allstrs(self):
-        strings = set([str(self), self.name, self.latex()])
-        strings.update(self.str_without(ss) for ss in self.subscripts)
-        return strings
 
     def __getattr__(self, attr):
         return self.descr.get(attr, None)

--- a/gpkit/varkey.py
+++ b/gpkit/varkey.py
@@ -48,14 +48,14 @@ class VarKey(object):
             value = self.descr["value"]
             if isinstance(value, Quantity):
                 self.descr["value"] = value.magnitude
-                self.descr["units"] = 1*value.units
+                self.descr["units"] = Quantity(1.0, value.units)
         if ureg and "units" in self.descr:
             units = self.descr["units"]
             if isinstance(units, Strings):
                 units = units.replace("-", "dimensionless")
                 self.descr["units"] = Quantity(1.0, units)
             elif isinstance(units, Quantity):
-                self.descr["units"] = 1*units.units
+                self.descr["units"] = Quantity(1.0, units.units)
             else:
                 raise ValueError("units must be either a string"
                                  " or a Quantity from gpkit.units.")

--- a/gpkit/varkey.py
+++ b/gpkit/varkey.py
@@ -48,14 +48,14 @@ class VarKey(object):
             value = self.descr["value"]
             if isinstance(value, Quantity):
                 self.descr["value"] = value.magnitude
-                self.descr["units"] = value/value.magnitude
+                self.descr["units"] = 1*value.units
         if ureg and "units" in self.descr:
             units = self.descr["units"]
             if isinstance(units, Strings):
                 units = units.replace("-", "dimensionless")
                 self.descr["units"] = Quantity(1.0, units)
             elif isinstance(units, Quantity):
-                self.descr["units"] = units/units.magnitude
+                self.descr["units"] = 1*units.units
             else:
                 raise ValueError("units must be either a string"
                                  " or a Quantity from gpkit.units.")


### PR DESCRIPTION
@whoburg, ready for review.

## Results
With `gas_hale`, latest commit / master

| Operation | Time (%) |  Biggest cause of slowness in refactor |
|---|---|---|
| Parse student's code  | 50/47  | ???  | 
| Rename model  | 25/0  | slow NomialData generation | 
| Generate GP | 22/14 | slow Nomial generation | 
| Solve | 10 | the solver (mosek here: cvxopt is 10x slower on my computer) | 
| Compile result | 20/0 | calculating var_senss for each PosyIneq separately | 

## Conclusion
We added two new parsing steps: one a proper varkey renaming, the other a recursive result compilation. These are slow: this model changes from spending 86% of its time in GPkit to spending 92% of its time there (or 37/53% with cvxopt). Honestly, the big problem is how slow we are on the user-given code.

I'm still in favor of merging the refactor in over master. 