### PR TITLE
faster simplify_posy_ineq, add test

### DIFF
--- a/gpkit/nomials/nomial_math.py
+++ b/gpkit/nomials/nomial_math.py
@@ -431,17 +431,18 @@ class ScalarSingleEquationConstraint(SingleEquationConstraint):
 def simplify_posy_ineq(exps, cs):
     "Simplify a posy <= 1 posynomial by moving constants to the right side."
     coeff = 1.0
-    count = 0
-    exps_ = list(exps)
+    exps_ = []
+    nonzero_exp_ixs = []
     for i, exp in enumerate(exps):
-        if not exp:
-            coeff -= mag(cs[i-count])
-            cs = np.hstack((cs[:i-count], cs[i+1-count:]))
-            exps_.pop(i-count)
-            count += 1
-            if coeff <= 0:
-                raise ValueError("infeasible constraint:"
-                                 " constant term too large.")
+        if exp:
+            nonzero_exp_ixs.append(i)
+            exps_.append(exp)
+        else:
+            coeff -= mag(cs[i])
+    if len(exps_) < len(exps):
+        if coeff <= 0:
+            raise ValueError("infeasible constraint: constant term too large.")
+        cs = cs[nonzero_exp_ixs]
     return tuple(exps_), cs/coeff
 
 

--- a/gpkit/tests/t_model.py
+++ b/gpkit/tests/t_model.py
@@ -194,10 +194,10 @@ class TestGP(unittest.TestCase):
         V = Variable('V', 1)
         m1 = Model(D + V, [V >= mi + 0.4])
         m2 = Model(D + 1, [1 >= mi + 0.4])
-        m1.solve(verbosity=0)
-        m2.solve(verbosity=0)
-        self.assertEqual(m1.program.A, m2.program.A)
-        self.assertTrue((m1.program.cs == m2.program.cs).all())
+        gp1, gp2 = m1.gp(verbosity=0), m2.gp(verbosity=0)
+        # pylint: disable=no-member
+        self.assertEqual(gp1.A, gp2.A)
+        self.assertTrue((gp1.cs == gp2.cs).all())
 
 
 class TestSP(unittest.TestCase):

--- a/gpkit/tests/t_model.py
+++ b/gpkit/tests/t_model.py
@@ -187,6 +187,18 @@ class TestGP(unittest.TestCase):
         m.solve(verbosity=0)
         self.assertEqual(type(m.program.cost.exps), tuple)
 
+    def test_posy_simplification(self):
+        "issue 525"
+        D = Variable('D')
+        mi = Variable('m_i')
+        V = Variable('V', 1)
+        m1 = Model(D + V, [V >= mi + 0.4])
+        m2 = Model(D + 1, [1 >= mi + 0.4])
+        m1.solve(verbosity=0)
+        m2.solve(verbosity=0)
+        self.assertEqual(m1.program.A, m2.program.A)
+        self.assertTrue((m1.program.cs == m2.program.cs).all())
+
 
 class TestSP(unittest.TestCase):
     """test case for SP class -- gets run for each installed solver"""


### PR DESCRIPTION
@bqpd, I think this implementation is a bit faster -- it should be O(len(cs)) instead of O(len(cs)*len(0exps)) for large exps and cs (if we ever encounter them)

also added a test