### PR TITLE
Call external code during localsolve

### DIFF
--- a/gpkit/constraints/model.py
+++ b/gpkit/constraints/model.py
@@ -104,7 +104,7 @@ class Model(CostedConstraintSet):
         if self.name:
             return "%s_%s" % (self.name, self.num)
 
-    def subconstr_tex(self, excluded=None):
+    def subconstr_latex(self, excluded=None):
         "The collapsed appearance of a ConstraintBase"
         if self.name:
             return "%s_{%s}" % (self.name, self.num)

--- a/gpkit/constraints/prog_factories.py
+++ b/gpkit/constraints/prog_factories.py
@@ -19,7 +19,7 @@ except (ImportError, IOError, AssertionError):
 
 def _progify_fctry(program, return_attr=None):
     "Generates function that returns a program() and optionally an attribute."
-    def programify(self, verbosity=1, substitutions=None):
+    def programify(self, verbosity=1, substitutions=None, **kwargs):
         """Return program version of self
 
         Arguments
@@ -31,7 +31,7 @@ def _progify_fctry(program, return_attr=None):
         """
         if not substitutions:
             substitutions = self.substitutions
-        prog = program(self.cost, [self], substitutions, verbosity)
+        prog = program(self.cost, self, substitutions, verbosity, **kwargs)
         if return_attr:
             return prog, getattr(prog, return_attr)
         else:

--- a/gpkit/constraints/set.py
+++ b/gpkit/constraints/set.py
@@ -20,7 +20,7 @@ class ConstraintSet(list):
                     self[i] = ConstraintSet(constraint)
         else:
             # grab the substitutions dict from the top constraintset
-            subs.update(constraints.substitutions)
+            subs.update(constraints.substitutions)  # pylint: disable=no-member
         self.substitutions = KeyDict.with_keys(self.varkeys,
                                                self._iter_subs(subs))
         # initializations for attributes used elsewhere

--- a/gpkit/constraints/set.py
+++ b/gpkit/constraints/set.py
@@ -8,6 +8,8 @@ from ..repr_conventions import _str, _repr, _repr_latex_
 class ConstraintSet(list):
     "Recursive container for ConstraintSets and Inequalities"
     def __init__(self, constraints, substitutions=None):
+        if isinstance(constraints, ConstraintSet):
+            constraints = [constraints]
         list.__init__(self, constraints)
         subs = substitutions if substitutions else {}
         if not isinstance(constraints, ConstraintSet):

--- a/gpkit/constraints/set.py
+++ b/gpkit/constraints/set.py
@@ -55,10 +55,11 @@ class ConstraintSet(list):
         if not excluded:
             excluded = ["units"]
         lines = []
-        if "root" not in excluded:
+        root = "root" not in excluded
+        if root:
             excluded.append("root")
             lines.append("\\begin{array}[ll] \\text{}")
-            root_latex = self.rootconstr_tex(excluded)
+            root_latex = self.rootconstr_latex(excluded)
             if root_latex:
                 lines.append(root_latex)
         for constraint in self:
@@ -66,16 +67,17 @@ class ConstraintSet(list):
             if cstr is None:
                 cstr = constraint.latex(excluded)
             if cstr[:6] != "    & ":  # require indentation
-                cstr = "    & " + cstr
+                cstr = "    & " + cstr + " \\\\"
             lines.append(cstr)
-        lines.append("\\end{array}")
+        if root:
+            lines.append("\\end{array}")
         return "\n".join(lines)
 
     def rootconstr_str(self, excluded=None):
         "The appearance of a ConstraintSet in addition to its contents"
         pass
 
-    def rootconstr_tex(self, excluded=None):
+    def rootconstr_latex(self, excluded=None):
         "The appearance of a ConstraintSet in addition to its contents"
         pass
 
@@ -83,7 +85,7 @@ class ConstraintSet(list):
         "The collapsed appearance of a ConstraintSet"
         pass
 
-    def subconstr_tex(self, excluded=None):
+    def subconstr_latex(self, excluded=None):
         "The collapsed appearance of a ConstraintSet"
         pass
 

--- a/gpkit/constraints/signomial_program.py
+++ b/gpkit/constraints/signomial_program.py
@@ -35,8 +35,7 @@ class SignomialProgram(CostedConstraintSet):
     >>> gp.solve()
     """
 
-    def __init__(self, cost, constraints, substitutions=None, verbosity=2,
-                 require_signomials=True):
+    def __init__(self, cost, constraints, substitutions=None, verbosity=1):
         # pylint: disable=unused-argument
         "Constructor. Required for objects inheriting from np.ndarray."
         if cost.any_nonpositive_cs:
@@ -46,14 +45,13 @@ class SignomialProgram(CostedConstraintSet):
     a dummy variable z to be greater than the desired Signomial objective s
     (z >= s) and then minimizing that dummy variable.""")
         CostedConstraintSet.__init__(self, cost, constraints, substitutions)
-        if require_signomials:
-            try:
-                _ = self.as_posyslt1()  # should raise an error
-                # TODO: is there a faster way to check?
-            except ValueError:
-                pass
-            else:  # this is a GP
-                raise ValueError("""No Signomials remained after substitution.
+        try:
+            _ = self.as_posyslt1()  # should raise an error
+            # TODO: is there a faster way to check?
+        except ValueError:
+            pass
+        else:  # this is a GP
+            raise ValueError("""No Signomials remained after substitution.
 
     SignomialPrograms should only be created with Models containing Signomial
     Constraints, since Models without Signomials have global solutions and can

--- a/gpkit/constraints/signomial_program.py
+++ b/gpkit/constraints/signomial_program.py
@@ -35,7 +35,8 @@ class SignomialProgram(CostedConstraintSet):
     >>> gp.solve()
     """
 
-    def __init__(self, cost, constraints, substitutions=None, verbosity=2):
+    def __init__(self, cost, constraints, substitutions=None, verbosity=2,
+                 require_signomial=True):
         # pylint: disable=unused-argument
         "Constructor. Required for objects inheriting from np.ndarray."
         if cost.any_nonpositive_cs:
@@ -45,13 +46,14 @@ class SignomialProgram(CostedConstraintSet):
     a dummy variable z to be greater than the desired Signomial objective s
     (z >= s) and then minimizing that dummy variable.""")
         CostedConstraintSet.__init__(self, cost, constraints, substitutions)
-        try:
-            _ = self.as_posyslt1()  # should raise an error
-            # TODO: is there a faster way to check?
-        except ValueError:
-            pass
-        else:  # this is a GP
-            raise ValueError("""No Signomials remained after substitution.
+        if require_signomial:
+            try:
+                _ = self.as_posyslt1()  # should raise an error
+                # TODO: is there a faster way to check?
+            except ValueError:
+                pass
+            else:  # this is a GP
+                raise ValueError("""No Signomials remained after substitution.
 
     SignomialPrograms should only be created with Models containing Signomial
     Constraints, since Models without Signomials have global solutions and can

--- a/gpkit/constraints/signomial_program.py
+++ b/gpkit/constraints/signomial_program.py
@@ -36,7 +36,7 @@ class SignomialProgram(CostedConstraintSet):
     """
 
     def __init__(self, cost, constraints, substitutions=None, verbosity=2,
-                 require_signomial=True):
+                 require_signomials=True):
         # pylint: disable=unused-argument
         "Constructor. Required for objects inheriting from np.ndarray."
         if cost.any_nonpositive_cs:
@@ -46,7 +46,7 @@ class SignomialProgram(CostedConstraintSet):
     a dummy variable z to be greater than the desired Signomial objective s
     (z >= s) and then minimizing that dummy variable.""")
         CostedConstraintSet.__init__(self, cost, constraints, substitutions)
-        if require_signomial:
+        if require_signomials:
             try:
                 _ = self.as_posyslt1()  # should raise an error
                 # TODO: is there a faster way to check?

--- a/gpkit/interactive/widgets.py
+++ b/gpkit/interactive/widgets.py
@@ -54,8 +54,11 @@ def modelinteract(model, ranges=None, fn_of_sol=None, **solvekwargs):
         # pylint: disable=function-redefined
         def fn_of_sol(solution):
             "Display function to run when a slider is moved."
-            tables = ["cost", "freevariables", "sensitivities"]
-            print solution.table(tables)
+            if hasattr(solution, "table"):
+                tables = ["cost", "freevariables", "sensitivities"]
+                print solution.table(tables)
+            else:
+                print solution["variables"]
 
     solvekwargs["verbosity"] = 0
 
@@ -65,9 +68,9 @@ def modelinteract(model, ranges=None, fn_of_sol=None, **solvekwargs):
         try:
             try:
                 model.solve(**solvekwargs)
-            except ValueError:
+            except (AttributeError, ValueError):
                 model.localsolve(**solvekwargs)
-            fn_of_sol(model.solution)
+            fn_of_sol(getattr(model, "solution", model.result))
         except RuntimeWarning:
             raise
             # TODO: implement some nicer feasibility warning, like the below

--- a/gpkit/interactive/widgets.py
+++ b/gpkit/interactive/widgets.py
@@ -70,7 +70,11 @@ def modelinteract(model, ranges=None, fn_of_sol=None, **solvekwargs):
                 model.solve(**solvekwargs)
             except (AttributeError, ValueError):
                 model.localsolve(**solvekwargs)
-            fn_of_sol(getattr(model, "solution", model.result))
+            if hasattr(model, "solution"):
+                sol = model.solution
+            else:
+                sol = model.result
+            fn_of_sol(sol)
         except RuntimeWarning:
             raise
             # TODO: implement some nicer feasibility warning, like the below


### PR DESCRIPTION
Sub discussions:

- [x] what should a locally-GP-approximable-but-non-SP program be called? https://github.com/hoburg/gpkit/issues/599#issuecomment-201046860
    - resolved by just calling it a regular SP for now and requesting that example code fail when called as a GP if it wants to work with controlpanel.


Up-to-date example:

```python
from gpkit import VectorVariable, Variable, units, SignomialProgram, Model
import gpkit
from gpkit.constraints.set import ConstraintSet

Re = Variable("Re", 1e6, "-", "Reynolds Number")
CL = Variable("C_L", "-", "Lift Coefficient")
CLmax = Variable("C_{L,max}", 1.0, "-", "Lift Coefficient")
CD = Variable("C_D", "-", "Drag Coefficient")


def xfoil(x0):
    return [CD >= 0.01 + .03*CL**2]


class AeroModel(ConstraintSet):

    def as_posyslt1(self):
        raise ValueError("AeroModel is not allowed to solve as a GP.")

    def as_gpconstr(self, x0):
        gpconstr = super(AeroModel, self).as_gpconstr(x0)
        if x0 and x0["Re"] >= 1e6:
            constraints = xfoil(x0)
        else:
            constraints = [CD >= 1. + CL**2]
        return ConstraintSet([gpconstr, constraints])

constraints = AeroModel([CL >= CLmax, Re >= 1e4*CL])

objective = CD

m = Model(objective, constraints)
# m.localsolve('cvxopt', verbosity=1)
m.controlpanel()
```