### PR TITLE
switch ValueError to TypeError in interactive

### DIFF
--- a/gpkit/interactive/widgets.py
+++ b/gpkit/interactive/widgets.py
@@ -68,7 +68,8 @@ def modelinteract(model, ranges=None, fn_of_sol=None, **solvekwargs):
         try:
             try:
                 model.solve(**solvekwargs)
-            except (AttributeError, ValueError):
+            except (AttributeError, TypeError):
+                # TypeError raised by as_posyslt1 in non-GP-compatible models
                 model.localsolve(**solvekwargs)
             if hasattr(model, "solution"):
                 sol = model.solution


### PR DESCRIPTION
This fixes a carry-over problem in interactive from 4c63942a90dd9f05d70ee0aa02e9ce3dbfcbd034

ready for review.