### PR TITLE
patch and test pint issue 366, fixes #694

### DIFF
--- a/gpkit/__init__.py
+++ b/gpkit/__init__.py
@@ -45,6 +45,8 @@ def enable_units(path=None):
             UNIT_REGISTRY = pint.UnitRegistry() # use pint default
             path = os_sep.join([os_path_dirname(__file__), "pint"])
             UNIT_REGISTRY.load_definitions(os_sep.join([path, "usd_cpi.txt"]))
+            # next line patches https://github.com/hgrecco/pint/issues/366
+            UNIT_REGISTRY.define("nautical_mile = 1852 m = nmi")
         units = UNIT_REGISTRY
         DimensionalityError = pint.DimensionalityError
     except ImportError:

--- a/gpkit/tests/t_small.py
+++ b/gpkit/tests/t_small.py
@@ -58,6 +58,12 @@ class TestSmallScripts(unittest.TestCase):
         self.assertEqual(unitstr(gpkit.Variable("y"), dimless="---"), "---")
         self.assertEqual(unitstr(None, dimless="--"), "")
 
+    def test_pint_366(self):
+        # test for https://github.com/hgrecco/pint/issues/366
+        if gpkit.units:
+            self.assertEqual(unitstr(gpkit.units("nautical_mile")), "nmi")
+            self.assertEqual(gpkit.units("nautical_mile"), gpkit.units("nmi"))
+
 
 TESTS = [TestHashVector, TestSmallScripts]
 


### PR DESCRIPTION
we can remove the `__init__.py` patch once https://github.com/hgrecco/pint/issues/366 is fixed (I'm watching it).

Ready for review.

@pgkirsch 