### PR TITLE
Make it possible to pass arguments to cvxopt solver

### DIFF
--- a/gpkit/_cvxopt.py
+++ b/gpkit/_cvxopt.py
@@ -2,10 +2,8 @@
 from cvxopt import solvers, spmatrix, matrix, log
 
 
-def cvxoptimize_fn(options=None):
-    "Return a cvxopt solve function for a particular set of options."
-    if options:
-        solvers.options.update(options)
+def cvxoptimize_fn():
+    "Return a cvxopt solve function"
     gpsolver = solvers.gp
 
     # pylint: disable=unused-argument

--- a/gpkit/geometric_program.py
+++ b/gpkit/geometric_program.py
@@ -152,7 +152,7 @@ class GeometricProgram(NomialData):
 
             if solver == "cvxopt":
                 from ._cvxopt import cvxoptimize_fn
-                solverfn = cvxoptimize_fn(*args, **kwargs)
+                solverfn = cvxoptimize_fn()
             elif solver == "mosek_cli":
                 from ._mosek import cli_expopt
                 solverfn = cli_expopt.imize_fn(*args, **kwargs)

--- a/gpkit/tests/t_model.py
+++ b/gpkit/tests/t_model.py
@@ -390,10 +390,22 @@ class TestSP(unittest.TestCase):
         self.assertEqual(first_gp_constr_posy.exp[x.key], -1./3)
 
 
-TEST_CASES = [TestGP, TestSP]
+class TestModelSolverSpecific(unittest.TestCase):
+    """test cases run only for specific solvers"""
+    def test_cvxopt_kwargs(self):
+        if "cvxopt" not in settings["installed_solvers"]:
+            return
+        x = Variable("x")
+        m = Model(x, [x >= 12])
+        # make sure it's possible to pass the kktsolver option to cvxopt
+        sol = m.solve(solver="cvxopt", verbosity=0, kktsolver="ldl")
+        self.assertAlmostEqual(sol["cost"], 12., NDIGS["cvxopt"])
 
-TESTS = []
-for testcase in TEST_CASES:
+
+TESTS = [TestModelSolverSpecific]
+MULTI_SOLVER_TESTS = [TestGP, TestSP]
+
+for testcase in MULTI_SOLVER_TESTS:
     for solver in settings["installed_solvers"]:
         if solver:
             test = type(testcase.__name__+"_"+solver,


### PR DESCRIPTION
Fixed a bug and added a test. See inline comments for more details.