### PR TITLE
fix bug with hashing of Variables with units; add test

### DIFF
--- a/gpkit/nomials/data.py
+++ b/gpkit/nomials/data.py
@@ -46,7 +46,9 @@ class NomialData(object):
         if self._hashvalue is None:
             # confirm lengths before calling zip
             assert len(self.exps) == len(self.cs)
-            self._hashvalue = hash(tuple(zip(self.exps, self.cs)))
+            # identical pint.Quantity object instances have different hashes
+            self._hashvalue = hash(tuple(zip(self.exps, mag(self.cs)) +
+                                         [str(self.units)]))
         return self._hashvalue
 
     @classmethod

--- a/gpkit/tests/t_vars.py
+++ b/gpkit/tests/t_vars.py
@@ -100,6 +100,20 @@ class TestVariable(unittest.TestCase):
         self.assertEqual(p1, p2)
         self.assertEqual(a.value, a)
 
+    def test_hash(self):
+        """Hashes should collide independent of units"""
+        x1 = Variable("x", "-", "first x")
+        x2 = Variable("x", "-", "second x")
+        self.assertEqual(hash(x1), hash(x2))
+        p1 = Variable("p", "psi", "first pressure")
+        p2 = Variable("p", "psi", "second pressure")
+        self.assertEqual(hash(p1), hash(p2))
+        xu = Variable("x", "m", "x with units")
+        if gpkit.units:
+            self.assertNotEqual(hash(x1), hash(xu))
+        else:
+            self.assertEqual(hash(x1), hash(xu))
+
 
 class TestVectorVariable(unittest.TestCase):
     """TestCase for the VectorVariable class.


### PR DESCRIPTION
found a bug: identical Variables with units have different hashes.

@bqpd, could this explain the problem you were having with getting @pgkirsch's models to run with your refactor in progress?

ready for review after passing CI.