### PR TITLE
Added sol["cost"] and fixed a couple typos

### DIFF
--- a/docs/source/advancedcommands.rst
+++ b/docs/source/advancedcommands.rst
@@ -120,7 +120,7 @@ Note that units are preserved, and that the value can be either a string (in whi
 Substituting with replacement
 ------------------------------
 
-Any of the substitutions above can be run with ``p.sub(*args, replace=True)`` to clobber any previously-substitued values.
+Any of the substitutions above can be run with ``p.sub(*args, replace=True)`` to clobber any previously-substituted values.
 
 Fixed Variables
 ---------------
@@ -159,7 +159,7 @@ Sweeps
 Declaring Sweeps
 ----------------
 
-Sweeps are useful for analyzing tradeoff surfaces. A sweep “value” is an Iterable of numbers, e.g. ``[1, 2, 3]``. Variables are swept when their substitution value takes the form ``('sweep', Iterable), (e.g. 'sweep', np.linspace(1e6, 1e7, 100))``. During variable declaration, giving an Iterable value for a Variable is assumed to be giving it a sweeep value: for example, ``x = Variable("x", [1, 2, 3]``. Sweeps can also be declared during later substitution (``gp.sub("x", ('sweep', [1, 2, 3]))``, or if the variable was already substituted for a constant, ``gp.sub("x", ('sweep', [1, 2, 3]), replace=True))``.
+Sweeps are useful for analyzing tradeoff surfaces. A sweep “value” is an Iterable of numbers, e.g. ``[1, 2, 3]``. Variables are swept when their substitution value takes the form ``('sweep', Iterable), (e.g. 'sweep', np.linspace(1e6, 1e7, 100))``. During variable declaration, giving an Iterable value for a Variable is assumed to be giving it a sweep value: for example, ``x = Variable("x", [1, 2, 3]``. Sweeps can also be declared during later substitution (``gp.sub("x", ('sweep', [1, 2, 3]))``, or if the variable was already substituted for a constant, ``gp.sub("x", ('sweep', [1, 2, 3]), replace=True))``.
 
 Solving Sweeps
 --------------

--- a/docs/source/gettingstarted.rst
+++ b/docs/source/gettingstarted.rst
@@ -158,12 +158,16 @@ We can also manually print the solution table, with the same result as if the ve
     -------------
     S : -1.5
 
+We can also print the optimal value and solved variables individually.
+
 .. code-block:: python
 
+    print "The optimal value is %s." % (sol["cost"])
     print "The x dimension is %s." % (sol(x))
 
 ::
 
+    The optimal value is 15.5884619886.
     The x dimension is 0.577351209028 meter.
 
 .. refactor this section; explain what can be done with a SolutionArray


### PR DESCRIPTION
Added more detail to the documentation explaining sol["cost"] in the "Getting Started" page under the "Printing Results" section, and fixed two typos I found on the "Advanced Commands" page.