### PR TITLE
change tolerance for mosek on Ubuntu16

### DIFF
--- a/gpkit/tests/t_solution_array.py
+++ b/gpkit/tests/t_solution_array.py
@@ -23,8 +23,8 @@ class TestSolutionArray(unittest.TestCase):
         y = Variable("y", "m")
         m = Model(y, [y >= x])
         sol = m.solve(verbosity=0)
-        self.assertAlmostEqual(sol("y")/sol("x"), 1.0)
-        self.assertAlmostEqual(sol(x)/sol(y), 1.0)
+        self.assertAlmostEqual(sol("y")/sol("x"), 1.0, 6)
+        self.assertAlmostEqual(sol(x)/sol(y), 1.0, 6)
 
     def test_call_vector(self):
         n = 5


### PR DESCRIPTION
e-mail chain leading to this (newest to oldest):


```
Units don’t affect that at all; looks like most of the tolerances for mosek default to 1e-8 or smaller, although MSK_DPAR_INTPNT_NL_TOL_REL_GAP  defaults to 1e-6.
http://docs.mosek.com/7.0/capi/The_optimizers_for_continuous_problems.html#ch-lin-opt-tab-nlo-term-cri

I’ll begrudgingly try turning ndigits on that test to 6.

On Aug 6, 2016, at 9:31 AM, Marshall C. Galbraith wrote:

I presume the solver is iterative and has a convergence tolerance. How do unit impact that tolerance?
From: Warren W Hoburg
Sent: Saturday, August 06, 2016 9:27 AM
To: Marshall C. Galbraith
Cc: Edward (Ned) Burnell
Subject: Re: Ubuntu 16

How can we possibly be passing test_call (which has a 10 digit tolerance!) and failing test_call_units?


    def test_call(self):
        A = Variable('A', '-', 'Test Variable')
        prob = Model(A, [A >= 1])
        sol = prob.solve(verbosity=0)
        self.assertAlmostEqual(sol(A), 1.0, 10)

    def test_call_units(self):
        # test from issue541
        x = Variable("x", 10, "ft")
        y = Variable("y", "m")
        m = Model(y, [y >= x])
        sol = m.solve(verbosity=0)
        self.assertAlmostEqual(sol("y")/sol("x"), 1.0)
        self.assertAlmostEqual(sol(x)/sol(y), 1.0)


On Aug 6, 2016, at 9:26 AM, Marshall C. Galbraith wrote:

The pint version is printed as part of the script right before the tests are run.

Yeah looks like your 7 places is right on the threshold. Either relaxing the tolerance on the test or tightening the tolerance on the solver should fix this.

Thanks,
Marshall
From: Warren W Hoburg
Sent: Saturday, August 06, 2016 9:22 AM
To: Marshall C. Galbraith
Cc: Edward (Ned) Burnell
Subject: Re: Ubuntu 16

Hmm, I ran the test below on my machine and it also fails. I don’t understand the ndig cutoff, but at least it’s consistent.

Not sure why this answer comes out further from 1.0 on this particular platform. Probably the best solution is for us to relax the cutoff slightly.


##### test I just ran on my machine

import unittest


class TestUnittestFramework(unittest.TestCase):

    def test_assert_almost_equal(self):
        self.assertAlmostEqual(0.99999990700595875, 1.0)


if __name__ == "__main__":
    suite = unittest.TestSuite()
    loader = unittest.TestLoader()
    for t in [TestUnittestFramework]:
        suite.addTests(loader.loadTestsFromTestCase(t))
    unittest.TextTestRunner().run(suite)


On Aug 6, 2016, at 9:08 AM, Warren Hoburg wrote:

Actually never mind, I don’t think this is a pint issue; it’s simply the

Traceback (most recent call last):
  File "/home/jenkins/workspace/gpkit_PullRequest_Unit/buildnode/reynolds-ubuntu16/optimizer/mosek/gpkit/tests/t_solution_array.py", line 26, in test_call_units
    self.assertAlmostEqual(sol("y")/sol("x"), 1.0)
AssertionError: 0.99999990700595875 != 1.0 within 7 places

I disagree: 1 - 0.99999990700595875 is 9.299404124529786e-08! How is that not within 7 places?


On Aug 6, 2016, at 9:05 AM, Warren Hoburg wrote:

What version of pint is on that machine?

On Aug 6, 2016, at 9:01 AM, Warren Hoburg wrote:

Thanks!  Yes it does… hmm.

On Aug 5, 2016, at 11:42 AM, Marshall C. Galbraith wrote:

I added the ubuntu 16 VM to test gpkit, and this pint failure looks eerily familiar...

https://acdl.mit.edu/csi/job/gpkit_PullRequest_Unit/buildnode=reynolds-ubuntu16,optimizer=mosek/1380/console
```