### PR TITLE
reduce number of keys to make keydicts faster

### DIFF
--- a/gpkit/keydict.py
+++ b/gpkit/keydict.py
@@ -22,7 +22,6 @@ class KeyDict(dict):
      - x.key
      - x.name (a string)
      - "x_modelname" (x's name including modelname)
-     - "{x}_{modelname}" (by convention, for latex)
 
     In addition, if collapse_arrays is True then VarKeys which have a `shape`
     parameter (indicating they are part of an array) are stored as numpy

--- a/gpkit/tests/t_keydict.py
+++ b/gpkit/tests/t_keydict.py
@@ -24,7 +24,6 @@ class TestKeyDict(unittest.TestCase):
         self.assertEqual(kd[x.key], 52)
         self.assertEqual(kd["x"], 52)
         self.assertEqual(kd["x_motor"], 52)
-        self.assertEqual(kd["{x}_{motor}"], 52)
         self.assertNotIn("x_someothermodelname", kd)
 
     def test_dictlike(self):

--- a/gpkit/varkey.py
+++ b/gpkit/varkey.py
@@ -74,7 +74,7 @@ class VarKey(object):
         selfstr = str(self)
         self._hashvalue = hash(selfstr)
         self.key = self
-        self.keys = set([self, self.name, selfstr, self.latex(),
+        self.keys = set([self.name, selfstr,
                          self.str_without("models")])
         if "idx" in self.descr:
             self.veckey = veckeyed(self)


### PR DESCRIPTION
I tried doing something fancy, but this worked better. :-/