### PR TITLE
KeyDict: failed __getitem__ causes state change

### DIFF
--- a/gpkit/keydict.py
+++ b/gpkit/keydict.py
@@ -89,6 +89,7 @@ class KeyDict(dict):
         key, idx = self.parse_and_index(key)
         keys = self.keymap[key]
         if not keys:
+            del self.keymap[key]
             raise KeyError("%s was not found." % key)
         values = []
         for key in keys:

--- a/gpkit/keydict.py
+++ b/gpkit/keydict.py
@@ -89,7 +89,7 @@ class KeyDict(dict):
         key, idx = self.parse_and_index(key)
         keys = self.keymap[key]
         if not keys:
-            del self.keymap[key]
+            del self.keymap[key] # remove blank entry added due to defaultdict
             raise KeyError("%s was not found." % key)
         values = []
         for key in keys:

--- a/gpkit/tests/t_keydict.py
+++ b/gpkit/tests/t_keydict.py
@@ -30,7 +30,7 @@ class TestKeyDict(unittest.TestCase):
         kd = KeyDict()
         with self.assertRaises(KeyError):
             _ = kd["waldo"]
-            # a failed __getitem__ causes potential state change (issue 893)
+            # issue 893: failed __getitem__ caused state change
         self.assertNotIn("waldo", kd)
         kd.update({"waldo": 5})
         res = kd["waldo"]

--- a/gpkit/tests/t_keydict.py
+++ b/gpkit/tests/t_keydict.py
@@ -26,6 +26,18 @@ class TestKeyDict(unittest.TestCase):
         self.assertEqual(kd["x_motor"], 52)
         self.assertNotIn("x_someothermodelname", kd)
 
+    def test_failed_getattr(self):
+        kd = KeyDict()
+        with self.assertRaises(KeyError):
+            _ = kd["waldo"]
+            # a failed __getitem__ causes potential state change (issue 893)
+        # TODO uncomment next assertNotIn after getting rest of test working
+        # self.assertNotIn("waldo", kd)
+        kd.update({"waldo": 5})
+        res = kd["waldo"]
+        self.assertEqual(res, 5)
+        self.assertIn("waldo", kd)
+
     def test_dictlike(self):
         kd = KeyDict()
         kd["a string key"] = "a string value"

--- a/gpkit/tests/t_keydict.py
+++ b/gpkit/tests/t_keydict.py
@@ -31,8 +31,7 @@ class TestKeyDict(unittest.TestCase):
         with self.assertRaises(KeyError):
             _ = kd["waldo"]
             # a failed __getitem__ causes potential state change (issue 893)
-        # TODO uncomment next assertNotIn after getting rest of test working
-        # self.assertNotIn("waldo", kd)
+        self.assertNotIn("waldo", kd)
         kd.update({"waldo": 5})
         res = kd["waldo"]
         self.assertEqual(res, 5)


### PR DESCRIPTION
Found an issue where attempting to access a missing key from a KeyDict causes a state change where future updates and calls to `in` act incorrectly.

MWE is the attached test (also added as a commit to this PR):

```python
    def test_failed_getattr(self):
        kd = KeyDict()
        with self.assertRaises(KeyError):
            _ = kd["waldo"]
            # a failed __getitem__ causes potential state change (issue 893)
        # TODO uncomment next assertNotIn after getting rest of test working
        # self.assertNotIn("waldo", kd)
        kd.update({"waldo": 5})
        res = kd["waldo"]
        self.assertEqual(res, 5)
        self.assertIn("waldo", kd)
```

Issue can arise in interactive sessions when someone checks whether something is in a Models'
 substitutions dict, gets a KeyError, and then cannot update that key from then onwards.