### PR TITLE
drop support for operator overloading with pint Quantity objects

### DIFF
--- a/docs/source/examples/beam.py
+++ b/docs/source/examples/beam.py
@@ -3,7 +3,7 @@ A simple beam example with fixed geometry. Solves the discretized
 Euler-Bernoulli beam equations for a constant distributed load
 """
 import numpy as np
-from gpkit import Variable, VectorVariable, Model, units
+from gpkit import Variable, VectorVariable, Model, ureg
 from gpkit.small_scripts import mag
 
 
@@ -60,11 +60,11 @@ print sol.table()
 w_gp = sol("w")  # deflection along beam
 
 L, EI, q = sol("L"), sol("EI"), sol("q")
-x = np.linspace(0, mag(L), len(q))*units.m  # position along beam
+x = np.linspace(0, mag(L), len(q))*ureg.m  # position along beam
 q = q[0]  # assume uniform loading for the check below
 w_exact = q/(24.*EI) * x**2 * (x**2 - 4*L*x + 6*L**2)  # analytic soln
 
-assert max(abs(w_gp - w_exact)) <= 1.1*units.cm
+assert max(abs(w_gp - w_exact)) <= 1.1*ureg.cm
 
 PLOT = False
 if PLOT:

--- a/gpkit/__init__.py
+++ b/gpkit/__init__.py
@@ -33,6 +33,7 @@ class GPkitUnits(object):
     def __init__(self):
         self.Quantity = ureg.Quantity  # pylint: disable=invalid-name
         if hasattr(ureg, "__nonzero__"):
+            # that is, if it's a DummyUnits object
             self.__nonzero__ = ureg.__nonzero__
             self.__bool__ = ureg.__bool__
 

--- a/gpkit/__init__.py
+++ b/gpkit/__init__.py
@@ -24,7 +24,23 @@ SIGNOMIALS_ENABLED = False
 
 # global variable initializations
 DimensionalityError = ValueError
-units = None
+ureg, units = None, None  # pylint: disable=invalid-name
+
+
+class GPkitUnits(object):
+    "Return monomials instead of Quantitites"
+
+    def __init__(self):
+        self.Quantity = ureg.Quantity  # pylint: disable=invalid-name
+        if hasattr(ureg, "__nonzero__"):
+            self.__nonzero__ = ureg.__nonzero__
+            self.__bool__ = ureg.__bool__
+
+    def __getattr__(self, attr):
+        return Monomial(self.Quantity(1, getattr(ureg, attr)))
+
+    def __call__(self, arg):
+        return Monomial(self.Quantity(1, ureg(arg)))
 
 
 def enable_units(path=None):
@@ -35,7 +51,7 @@ def enable_units(path=None):
 
     If gpkit is imported multiple times, this needs to be run each time."""
     # pylint: disable=invalid-name,global-statement
-    global units, DimensionalityError, UNIT_REGISTRY
+    global DimensionalityError, UNIT_REGISTRY, ureg, units
     try:
         import pint
         if path:
@@ -47,8 +63,10 @@ def enable_units(path=None):
             UNIT_REGISTRY.load_definitions(os_sep.join([path, "usd_cpi.txt"]))
             # next line patches https://github.com/hgrecco/pint/issues/366
             UNIT_REGISTRY.define("nautical_mile = 1852 m = nmi")
-        units = UNIT_REGISTRY
+
+        ureg = UNIT_REGISTRY
         DimensionalityError = pint.DimensionalityError
+        units = GPkitUnits()
     except ImportError:
         print("Optional Python units library (Pint) not installed;"
               " unit support disabled.")
@@ -71,7 +89,7 @@ def disable_units():
         from gpkit import disable_units
         disable_units()
     """
-    global units  # pylint: disable=global-statement
+    global ureg, units  # pylint: disable=invalid-name,global-statement
 
     class DummyUnits(object):
         "Dummy class to replace missing pint"
@@ -91,7 +109,8 @@ def disable_units():
         def __call__(self, arg):
             return 1
 
-    units = DummyUnits()
+    ureg = DummyUnits()
+    units = ureg
 
 enable_units()
 
@@ -129,33 +148,6 @@ from .constraints.signomial_program import SignomialProgram
 from .constraints.set import ConstraintSet
 from .constraints.model import Model
 from .constraints.linked import LinkedConstraintSet
-
-if units:
-    def _subvert_pint():
-        """
-        When gpkit objects appear in mathematical operations with pint
-        Quantity objects, let the gpkit implementations determine what to do
-        """
-        def skip_if_gpkit_objects(fallback, objects=(Nomial, NomialArray)):
-            """Returned method calls self.fallback(other) if other is
-            not in objects, and otherwise returns NotImplemented.
-            """
-            def _newfn(self, other):
-                if isinstance(other, objects):
-                    return NotImplemented
-                else:
-                    return getattr(self, fallback)(other)
-            return _newfn
-
-        for op in "eq ge le add mul div truediv floordiv".split():
-            dunder = "__%s__" % op
-            trunder = "___%s___" % op
-            original = getattr(units.Quantity, dunder)
-            setattr(units.Quantity, trunder, original)
-            newfn = skip_if_gpkit_objects(fallback=trunder)
-            setattr(units.Quantity, dunder, newfn)
-
-    _subvert_pint()
 
 
 def load_settings(path=SETTINGS_PATH):

--- a/gpkit/keydict.py
+++ b/gpkit/keydict.py
@@ -116,6 +116,12 @@ class KeyDict(dict):
                 emptyvec = np.full(key.shape, np.nan, **kwargs)
                 dict.__setitem__(self, key, emptyvec)
         for key in self.keymap[key]:
+            if getattr(value, "exp", None) is not None and not value.exp:
+                # get the value of variable-less monomials
+                # so that `x.sub({x: gpkit.units.m})`
+                # and `x.sub({x: gpkit.ureg.m})`
+                # are equivalent
+                value = value.value
             if idx:
                 dict.__getitem__(self, key)[idx] = value
             elif (dict.__contains__(self, key) and hasattr(value, "shape")

--- a/gpkit/nomials/array.py
+++ b/gpkit/nomials/array.py
@@ -13,7 +13,7 @@ from ..small_classes import Numbers
 from ..small_scripts import try_str_without
 from ..constraints import ArrayConstraint
 from ..repr_conventions import _str, _repr, _repr_latex_
-from .. import units as ureg
+from .. import ureg
 from .. import DimensionalityError
 Quantity = ureg.Quantity
 

--- a/gpkit/nomials/nomial_math.py
+++ b/gpkit/nomials/nomial_math.py
@@ -10,7 +10,7 @@ from ..small_classes import HashVector
 from ..keydict import KeySet
 from ..varkey import VarKey
 from ..small_scripts import mag
-from .. import units as ureg
+from .. import ureg
 from .. import DimensionalityError
 from ..exceptions import InvalidGPConstraint
 

--- a/gpkit/small_classes.py
+++ b/gpkit/small_classes.py
@@ -1,7 +1,7 @@
 """Miscellaneous small classes"""
 from collections import namedtuple
 import numpy as np
-from . import units as gpkitunits
+from . import ureg
 
 try:
     isinstance("", basestring)
@@ -9,7 +9,7 @@ try:
 except NameError:
     Strings = (str,)
 
-Quantity = gpkitunits.Quantity
+Quantity = ureg.Quantity
 Numbers = (int, float, np.number, Quantity)
 CootMatrixTuple = namedtuple('CootMatrix', ['row', 'col', 'data'])
 

--- a/gpkit/small_scripts.py
+++ b/gpkit/small_scripts.py
@@ -28,6 +28,8 @@ def unitstr(units, into="%s", options="~", dimless="-"):
     "Returns the unitstr of a given object."
     if hasattr(units, "descr") and hasattr(units.descr, "get"):
         units = units.descr.get("units", dimless)
+    if hasattr(units, "units") and isinstance(units.units, Quantity):
+        units = units.units
     if isinstance(units, Strings):
         return into % units if units else ""
     elif isinstance(units, Quantity):

--- a/gpkit/tests/t_nomials.py
+++ b/gpkit/tests/t_nomials.py
@@ -2,6 +2,7 @@
 import math
 import unittest
 from gpkit import Variable, Monomial, Posynomial, Signomial, SignomialsEnabled
+from gpkit import VectorVariable, NomialArray
 import gpkit
 
 
@@ -182,15 +183,24 @@ class TestMonomial(unittest.TestCase):
     def test_units(self):
         "make sure multiplication with units works (issue 492)"
         # have had issues where Quantity.__mul__ causes wrong return type
-        m = 1.2 * gpkit.units.ft * Variable('x')**2
+        m = 1.2 * gpkit.units.ft * Variable("x", "m")**2
         self.assertTrue(isinstance(m, Monomial))
         if m.units:
-            self.assertEqual(m.units, 1*gpkit.ureg.ft)
+            self.assertEqual(m.units, 1*gpkit.ureg.ft*gpkit.ureg.m**2)
         # also multiply at the end, though this has not been a problem
-        m = 0.5 * Variable('x')**2 * gpkit.units.kg
+        m = 0.5 * Variable("x", "m")**2 * gpkit.units.kg
         self.assertTrue(isinstance(m, Monomial))
         if m.units:
-            self.assertEqual(m.units, 1*gpkit.ureg.kg)
+            self.assertEqual(m.units, 1*gpkit.ureg.kg*gpkit.ureg.m**2)
+        # and with vectors...
+        v = 0.5 * VectorVariable(3, "x", "m")**2 * gpkit.units.kg
+        self.assertTrue(isinstance(v, NomialArray))
+        if v.units:
+            self.assertEqual(v.units, 1*gpkit.ureg.kg*gpkit.ureg.m**2)
+        v = 0.5 * gpkit.units.kg * VectorVariable(3, "x", "m")**2
+        self.assertTrue(isinstance(v, NomialArray))
+        if v.units:
+            self.assertEqual(v.units, 1*gpkit.ureg.kg*gpkit.ureg.m**2)
 
 
 class TestSignomial(unittest.TestCase):

--- a/gpkit/tests/t_nomials.py
+++ b/gpkit/tests/t_nomials.py
@@ -1,8 +1,8 @@
 """Tests for Monomial, Posynomial, and Signomial classes"""
 import math
 import unittest
-from gpkit import Variable, Monomial, Posynomial, Signomial
-from gpkit import units, SignomialsEnabled
+from gpkit import Variable, Monomial, Posynomial, Signomial, SignomialsEnabled
+import gpkit
 
 
 class TestMonomial(unittest.TestCase):
@@ -182,13 +182,15 @@ class TestMonomial(unittest.TestCase):
     def test_units(self):
         "make sure multiplication with units works (issue 492)"
         # have had issues where Quantity.__mul__ causes wrong return type
-        m = 1.2 * units.ft * Variable('x')**2
+        m = 1.2 * gpkit.units.ft * Variable('x')**2
         self.assertTrue(isinstance(m, Monomial))
-        self.assertEqual(m.units, 1*units.ft)
+        if m.units:
+            self.assertEqual(m.units, 1*gpkit.ureg.ft)
         # also multiply at the end, though this has not been a problem
-        m = 0.5 * Variable('x')**2 * units.kg
+        m = 0.5 * Variable('x')**2 * gpkit.units.kg
         self.assertTrue(isinstance(m, Monomial))
-        self.assertEqual(m.units, 1*units.kg)
+        if m.units:
+            self.assertEqual(m.units, 1*gpkit.ureg.kg)
 
 
 class TestSignomial(unittest.TestCase):

--- a/gpkit/tests/t_solution_array.py
+++ b/gpkit/tests/t_solution_array.py
@@ -67,9 +67,9 @@ class TestSolutionArray(unittest.TestCase):
         sol = m.solve(verbosity=0)
         Psol = sol.subinto(P_max)
         self.assertEqual(len(Psol), Nsweep)
-        self.assertAlmostEqual(0*gpkit.units.m,
-                               np.max(np.abs(Pvals*gpkit.units.m - Psol)))
-        self.assertAlmostEqual(0*gpkit.units.m,
+        self.assertAlmostEqual(0*gpkit.ureg.m,
+                               np.max(np.abs(Pvals*gpkit.ureg.m - Psol)))
+        self.assertAlmostEqual(0*gpkit.ureg.m,
                                np.max(np.abs(Psol - sol(P_max))))
 
     def test_table(self):
@@ -86,7 +86,7 @@ class TestSolutionArray(unittest.TestCase):
         T = Variable("T", "N", "thrust")
         Tmin = Variable("T_{min}", "N", "minimum thrust")
         m = Model(T, [T >= Tmin])
-        tminsub = 1000 * gpkit.units.lbf
+        tminsub = 1000 * gpkit.ureg.lbf
         m.substitutions.update({Tmin: tminsub})
         sol = m.solve(verbosity=0)
         self.assertEqual(sol(Tmin), tminsub)

--- a/gpkit/tests/t_sub.py
+++ b/gpkit/tests/t_sub.py
@@ -51,10 +51,10 @@ class TestNomialSubs(unittest.TestCase):
             self.assertEqual(x.sub({x: 1*gpkit.units.m}).c.magnitude, 100)
             # NOTE: uncomment the below if requiring Quantity substitutions
             # self.assertRaises(ValueError, x.sub, x, 1)
-            self.assertRaises(ValueError, x.sub, {x: 1*gpkit.units.N})
-            self.assertRaises(ValueError, y.sub, {y: 1*gpkit.units.N})
+            self.assertRaises(ValueError, x.sub, {x: 1*gpkit.ureg.N})
+            self.assertRaises(ValueError, y.sub, {y: 1*gpkit.ureg.N})
             v = gpkit.VectorVariable(3, "v", "cm")
-            subbed = v.sub({v: [1, 2, 3]*gpkit.units.m})
+            subbed = v.sub({v: [1, 2, 3]*gpkit.ureg.m})
             self.assertEqual([z.c.magnitude for z in subbed], [100, 200, 300])
 
     def test_scalar_units(self):
@@ -171,8 +171,8 @@ class TestGPSubs(unittest.TestCase):
         Q = Variable("Q", "count")
         Y = Variable("Y", "USD")
         m = Model(Y, [Y >= h*Q + A/Q])
-        m.substitutions.update({A: 500*gpkit.units("USD"),
-                                h: 35*gpkit.units("USD"),
+        m.substitutions.update({A: 500*gpkit.ureg("USD"),
+                                h: 35*gpkit.ureg("USD"),
                                 Q: ("sweep", [50, 100, 500])})
         firstcost = m.solve(verbosity=0)["cost"][0]
         self.assertAlmostEqual(firstcost, 1760, 3)
@@ -238,7 +238,7 @@ class TestGPSubs(unittest.TestCase):
         sol = m.solve(verbosity=0)
         solv = sol['variables']
         a = solv["xi"]
-        b = xi_dist*gpkit.units.N
+        b = xi_dist*gpkit.ureg.N
         self.assertTrue(all(abs(a-b)/(a+b) < 1e-7))
 
     def test_model_composition_units(self):
@@ -261,21 +261,21 @@ class TestGPSubs(unittest.TestCase):
         concat_cost = concatm.solve(verbosity=0)["cost"]
         almostequal = self.assertAlmostEqual
         if not isinstance(a["x"].key.units, str):
-            almostequal(1/gpkit.units.yd/a.solve(verbosity=0)["cost"], 1, 5)
-            almostequal(1*gpkit.units.cm/b.solve(verbosity=0)["cost"], 1, 5)
-            almostequal(1*gpkit.units.cm/gpkit.units.yd/concat_cost, 1, 5)
+            almostequal(1/gpkit.ureg.yd/a.solve(verbosity=0)["cost"], 1, 5)
+            almostequal(1*gpkit.ureg.cm/b.solve(verbosity=0)["cost"], 1, 5)
+            almostequal(1*gpkit.ureg.cm/gpkit.ureg.yd/concat_cost, 1, 5)
         a1, b1 = Above(), Below()
         m = a1.link(b1)
         m.cost = m["x"]
         sol = m.solve(verbosity=0)
         if not isinstance(m["x"].key.units, str):
-            almostequal(1*gpkit.units.cm/sol["cost"], 1, 5)
+            almostequal(1*gpkit.ureg.cm/sol["cost"], 1, 5)
         a1, b1 = Above(), Below()
         m = b1.link(a1)
         m.cost = m["x"]
         sol = m.solve(verbosity=0)
         if not isinstance(m["x"].key.units, str):
-            almostequal(1*gpkit.units.cm/sol["cost"], 1, 5)
+            almostequal(1*gpkit.ureg.cm/sol["cost"], 1, 5)
         self.assertIn(m["x"], sol["variables"])
         self.assertIn(a1["x"], sol["variables"])
         self.assertIn(b1["x"], sol["variables"])

--- a/gpkit/tests/t_sub.py
+++ b/gpkit/tests/t_sub.py
@@ -171,8 +171,8 @@ class TestGPSubs(unittest.TestCase):
         Q = Variable("Q", "count")
         Y = Variable("Y", "USD")
         m = Model(Y, [Y >= h*Q + A/Q])
-        m.substitutions.update({A: 500*gpkit.ureg("USD"),
-                                h: 35*gpkit.ureg("USD"),
+        m.substitutions.update({A: 500*gpkit.units("USD"),
+                                h: 35*gpkit.units("USD"),
                                 Q: ("sweep", [50, 100, 500])})
         firstcost = m.solve(verbosity=0)["cost"][0]
         self.assertAlmostEqual(firstcost, 1760, 3)

--- a/gpkit/tests/t_vars.py
+++ b/gpkit/tests/t_vars.py
@@ -154,13 +154,13 @@ class TestVectorVariable(unittest.TestCase):
     def test_constraint_creation_units(self):
         v = VectorVariable(2, "v", "m/s")
         c = (v >= 40*gpkit.units("ft/s"))
-        c2 = (v >= [20, 30]*gpkit.units("ft/s"))
+        c2 = (v >= np.array([20, 30])*gpkit.units("ft/s"))
         if gpkit.units:
             self.assertTrue(c.right.units)
-            self.assertTrue(c2.right.units)
+            self.assertTrue(NomialArray(c2.right).units)
         else:
             self.assertEqual(type(c.right), int)
-            self.assertEqual(type(c2.right), list)
+            self.assertEqual(type(c2.right), np.ndarray)
 
 
 class TestArrayVariable(unittest.TestCase):


### PR DESCRIPTION
This isn't an easy choice to make, but the following didn't work on master with pint 0.7 and something had to be done:
```python
    def test_units(self):
        "make sure multiplication with units works (issue 492)"
        # have had issues where Quantity.__mul__ causes wrong return type
        m = 1.2 * gpkit.units.ft * Variable("x", "m")**2
        self.assertEqual(type(m), Monomial)
        if m.units:
            self.assertEqual(m.units, 1*gpkit.units.ft*gpkit.units.m**2)
        # also multiply at the end, though this has not been a problem
        m = 0.5 * Variable("x", "m")**2 * gpkit.units.kg
        self.assertEqual(type(m), Monomial)
        if m.units:
            self.assertEqual(m.units, 1*gpkit.units.kg*gpkit.units.m**2)
        # and with vectors...
        v = 0.5 * VectorVariable(3, "x", "m")**2 * gpkit.units.kg
        self.assertEqual(type(v), NomialArray)  # is actually a Quantity...
        if v.units:
            self.assertEqual(v.units, 1*gpkit.units.kg*gpkit.units.m**2) # ...of units 'kg'!
        v = 0.5 * gpkit.units.kg * VectorVariable(3, "x", "m")**2
        self.assertEqual(type(v), NomialArray)  # same here
        if v.units:
            self.assertEqual(v.units, 1*gpkit.units.kg*gpkit.units.m**2 # and here
```

I tried enhancing our pint subversion, but whatever two-step process pint does in its operator overloading to turn iterables into quantities is buried deep, and I didn't want to extend the rickety cantilever of our subversions any further into pint.

So what this PR does is make `gpkit.units`, by default, return `Monomials`. This means we don't have to subvert pint anymore to get operator overloading working, everything's already a gpkit object during Model creation.

However, this means that: 

  1. substitutions of united quantities will now be of monomials / nomialarrays instead
    - so I decided to catch that in keydict and just store them as quantities
  2. solutions will be Quantities that can't interact directly with gpkit objects
    - this isn't a problem for substitution, just when a signomial is multiplied by a solution / solution vector. I don't see a great way to handle this, but an error is better than the weird silent failures we had before.