### PR TITLE
re-enable units after tests

### DIFF
--- a/gpkit/tests/run_tests.py
+++ b/gpkit/tests/run_tests.py
@@ -64,6 +64,7 @@ def run(xmloutput=False):
         run_tests(tests, xmloutput='test_reports_nounits')
     else:
         run_tests(tests, verbosity=1)
+    gpkit.enable_units()
 
 if __name__ == '__main__':
     run()


### PR DESCRIPTION
one-liner change

on the current master, if you run `python -c "from gpkit.tests import run; run(); from gpkit import Variable; assert Variable('x', 'ft').units is not None"`

you get:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
AssertionError
```

this fixes that.

@bqpd, ready for review