### PR TITLE
Full backwards compatibility with Vectorize and NamedVariables

### DIFF
--- a/gpkit/constraints/model.py
+++ b/gpkit/constraints/model.py
@@ -6,7 +6,9 @@ from ..geometric_program import GeometricProgram
 from .signomial_program import SignomialProgram
 from .linked import LinkedConstraintSet
 from ..small_scripts import mag
-from .. import end_variable_naming, begin_variable_naming, NamedVariables
+from ..keydict import KeyDict
+from ..varkey import VarKey
+from .. import end_variable_naming, begin_variable_naming, NamedVariables, SignomialsEnabled
 
 
 class Model(CostedConstraintSet):
@@ -55,23 +57,15 @@ class Model(CostedConstraintSet):
                 start_args = [cost, constraints]
                 args = tuple(a for a in start_args if a is not None) + args
                 constraints = self.setup(*args, **kwargs)  # pylint: disable=no-member
-                from .. import NAMEDVARS, MODELS, MODELNUMS
-                setup_vars = NAMEDVARS[tuple(MODELS), tuple(MODELNUMS)]
-                self.name, self.num = MODELS[:-1], MODELNUMS[:-1]
-                self.naming = (tuple(MODELS), tuple(MODELNUMS))
+                from .. import NAMEDVARS, MODELS, MODELNUM_LOOKUPS
+                setup_vars = NAMEDVARS[tuple(MODELS), tuple(MODELNUM_LOOKUPS)]
+                self.name, self.num = MODELS[:-1], MODELNUM_LOOKUPS[:-1]
+                self.naming = (tuple(MODELS), tuple(MODELNUM_LOOKUPS))
             cost = self.cost
         else:
             if args and not substitutions:
                 # backwards compatibility: substitutions as third arg
                 substitutions, = args
-            if self.__class__.__name__ != "Model":
-                from .. import NAMEDVARS, MODELS, MODELNUMS
-                print("Declaring a named Model's variables in __init__ is"
-                      " not recommended. For details see gpkit.rtfd.org")
-                self.name = self.__class__.__name__
-                self.num = MODELNUMS[name]
-                MODELNUMS[name] += 1
-                self._add_modelname_tovars(self.name, self.num)
 
         cost = cost if cost else Monomial(1)
         constraints = constraints if constraints else []
@@ -81,6 +75,15 @@ class Model(CostedConstraintSet):
             # even if they aren't used in any constraints
             self.unused_variables = setup_vars
             self.reset_varkeys()
+	if not hasattr(self, "setup"):
+            if self.__class__.__name__ != "Model":
+                from .. import MODELNUM_LOOKUP
+                print("Declaring a named Model's variables in __init__ is"
+                      " not recommended. For details see gpkit.rtfd.org")
+                self.name = self.__class__.__name__
+                self.num = MODELNUM_LOOKUP[self.name]
+                MODELNUM_LOOKUP[self.name] += 1
+                self._add_modelname_tovars(self.name, self.num)
 
     gp = _progify_fctry(GeometricProgram)
     sp = _progify_fctry(SignomialProgram)

--- a/gpkit/constraints/model.py
+++ b/gpkit/constraints/model.py
@@ -76,6 +76,7 @@ class Model(CostedConstraintSet):
             self.unused_variables = setup_vars
             self.reset_varkeys()
         # for backwards compatibility keep add_modelnames
+        # TODO: remove with linking
         if not hasattr(self, "setup") and self.__class__.__name__ != "Model":
             from .. import MODELNUM_LOOKUP
             print("Declaring a named Model's variables in __init__ is"
@@ -90,6 +91,7 @@ class Model(CostedConstraintSet):
     solve = _solve_fctry(_progify_fctry(GeometricProgram, "solve"))
     localsolve = _solve_fctry(_progify_fctry(SignomialProgram, "localsolve"))
 
+    # TODO: remove with linking
     def link(self, other, include_only=None, exclude=None):
         "Connects this model with a set of constraints"
         lc = LinkedConstraintSet([self, other], include_only, exclude)
@@ -116,6 +118,7 @@ class Model(CostedConstraintSet):
         if self.name:
             return "%s_{%s}" % (self.name, self.num)
 
+    # TODO: remove with linking
     def _add_modelname_tovars(self, name, num):
         add_model_subs = KeyDict()
         for vk in self.varkeys:

--- a/gpkit/constraints/model.py
+++ b/gpkit/constraints/model.py
@@ -8,7 +8,7 @@ from .linked import LinkedConstraintSet
 from ..small_scripts import mag
 from ..keydict import KeyDict
 from ..varkey import VarKey
-from .. import end_variable_naming, begin_variable_naming, NamedVariables, SignomialsEnabled
+from .. import NamedVariables, SignomialsEnabled
 
 
 class Model(CostedConstraintSet):
@@ -57,10 +57,10 @@ class Model(CostedConstraintSet):
                 start_args = [cost, constraints]
                 args = tuple(a for a in start_args if a is not None) + args
                 constraints = self.setup(*args, **kwargs)  # pylint: disable=no-member
-                from .. import NAMEDVARS, MODELS, MODELNUM_LOOKUPS
-                setup_vars = NAMEDVARS[tuple(MODELS), tuple(MODELNUM_LOOKUPS)]
-                self.name, self.num = MODELS[:-1], MODELNUM_LOOKUPS[:-1]
-                self.naming = (tuple(MODELS), tuple(MODELNUM_LOOKUPS))
+                from .. import NAMEDVARS, MODELS, MODELNUMS
+                setup_vars = NAMEDVARS[tuple(MODELS), tuple(MODELNUMS)]
+                self.name, self.num = MODELS[:-1], MODELNUMS[:-1]
+                self.naming = (tuple(MODELS), tuple(MODELNUMS))
             cost = self.cost
         else:
             if args and not substitutions:
@@ -75,15 +75,15 @@ class Model(CostedConstraintSet):
             # even if they aren't used in any constraints
             self.unused_variables = setup_vars
             self.reset_varkeys()
-	if not hasattr(self, "setup"):
-            if self.__class__.__name__ != "Model":
-                from .. import MODELNUM_LOOKUP
-                print("Declaring a named Model's variables in __init__ is"
-                      " not recommended. For details see gpkit.rtfd.org")
-                self.name = self.__class__.__name__
-                self.num = MODELNUM_LOOKUP[self.name]
-                MODELNUM_LOOKUP[self.name] += 1
-                self._add_modelname_tovars(self.name, self.num)
+        # for backwards compatibility keep add_modelnames
+        if not hasattr(self, "setup") and self.__class__.__name__ != "Model":
+            from .. import MODELNUM_LOOKUP
+            print("Declaring a named Model's variables in __init__ is"
+                  " not recommended. For details see gpkit.rtfd.org")
+            self.name = self.__class__.__name__
+            self.num = MODELNUM_LOOKUP[self.name]
+            MODELNUM_LOOKUP[self.name] += 1
+            self._add_modelname_tovars(self.name, self.num)
 
     gp = _progify_fctry(GeometricProgram)
     sp = _progify_fctry(SignomialProgram)


### PR DESCRIPTION
Undoes `__init__` speedups to implement exactly what we had before, because some models using `LinkedConstraintSet` rely upon it.

@whoburg this is a priority to merge, please review.