### PR TITLE
add script to test remote repositories

### DIFF
--- a/gpkit/nomials/data.py
+++ b/gpkit/nomials/data.py
@@ -97,9 +97,9 @@ class NomialData(object):
             var, = varset
         exps, cs = [], []
         # var.units may be str if units disabled
-        if not var.units:
+        if not var.units or isinstance(var.units, str):
             units = 1
-        elif isinstance(var.units, str):
+        else:
             if hasattr(self.cs, "units"):
                 cs_units = Quantity(1, self.cs.units)
             else:

--- a/gpkit/nomials/data.py
+++ b/gpkit/nomials/data.py
@@ -97,9 +97,9 @@ class NomialData(object):
             var, = varset
         exps, cs = [], []
         # var.units may be str if units disabled
-        if not var.units and not isinstance(var.units, str):
+        if not var.units:
             units = 1
-        else:
+        elif isinstance(var.units, str):
             if hasattr(self.cs, "units"):
                 cs_units = Quantity(1, self.cs.units)
             else:

--- a/gpkit/tests/from_paths.py
+++ b/gpkit/tests/from_paths.py
@@ -1,0 +1,58 @@
+"Runs each file listed in pwd/TESTS as a test"
+
+import unittest
+import os
+import re
+import importlib
+from gpkit import settings
+from gpkit.tests.helpers import generate_example_tests, new_test
+
+
+class TestFiles(unittest.TestCase):
+    "Stub to be filled with files in pwd/TEST"
+    pass
+
+
+def clean(s):
+    """Parses string into valid python variable name
+
+    https://stackoverflow.com/questions/3303312/
+    how-do-i-convert-a-string-to-a-valid-variable-name-in-python
+    """
+    s = re.sub('[^0-9a-zA-Z_]', '', s)  # Remove invalid characters
+    # Remove leading characters until we find a letter or underscore
+    s = re.sub('^[^a-zA-Z_]+', '', s)
+    return s
+
+
+def add_filetest(TestClass, path):
+    path = path.strip()
+    print "adding test for", repr(path)
+
+    def test_fn(self):
+        mod = importlib.import_module(path[:-3])
+        if not hasattr(mod, "test"):
+            self.fail("file '%s' had no `test` function." % path)
+        mod.test()
+
+    setattr(TestClass, "test_"+clean(path), test_fn)
+
+
+SOLVERS = settings["installed_solvers"]
+
+
+def newtest_fn(name, solver, import_dict, path):
+    "Doubly nested callbacks to run the test with `getattr(self, name)()`"
+    return new_test(name, solver, import_dict, path,
+                    testfn=(lambda name, import_dict, path:
+                            lambda self: getattr(self, name)()))
+
+
+def run(filename="TESTS", xmloutput=False):
+    with open(filename, "r") as f:
+        for path in f:
+            add_filetest(TestFiles, path)
+    TESTS = generate_example_tests("", [TestFiles], SOLVERS,
+                                   newtest_fn=newtest_fn)
+    from gpkit.tests.run_tests import run
+    run(tests=TESTS, unitless=False, xmloutput=xmloutput)

--- a/gpkit/tests/from_paths.py
+++ b/gpkit/tests/from_paths.py
@@ -1,6 +1,7 @@
 "Runs each file listed in pwd/TESTS as a test"
 
 import unittest
+import os
 import re
 import importlib
 from gpkit import settings
@@ -32,7 +33,14 @@ def add_filetest(testclass, path):
     print "adding test for", repr(path)
 
     def test_fn(self):
-        mod = importlib.import_module(path[:-3])
+        top_level = os.getcwd()
+        try:
+            dirname = os.path.dirname(path)
+            if dirname:
+                os.chdir(os.path.dirname(path))
+            mod = importlib.import_module(os.path.basename(path)[:-3])
+        finally:
+            os.chdir(top_level)
         if not hasattr(mod, "test"):
             self.fail("file '%s' had no `test` function." % path)
         mod.test()

--- a/gpkit/tests/from_paths.py
+++ b/gpkit/tests/from_paths.py
@@ -1,7 +1,6 @@
 "Runs each file listed in pwd/TESTS as a test"
 
 import unittest
-import os
 import re
 import importlib
 from gpkit import settings
@@ -13,19 +12,22 @@ class TestFiles(unittest.TestCase):
     pass
 
 
-def clean(s):
+def clean(string):
     """Parses string into valid python variable name
 
     https://stackoverflow.com/questions/3303312/
     how-do-i-convert-a-string-to-a-valid-variable-name-in-python
     """
-    s = re.sub('[^0-9a-zA-Z_]', '', s)  # Remove invalid characters
+    string = re.sub('[^0-9a-zA-Z_]', '', string)  # Remove invalid characters
     # Remove leading characters until we find a letter or underscore
-    s = re.sub('^[^a-zA-Z_]+', '', s)
-    return s
+    string = re.sub('^[^a-zA-Z_]+', '', string)
+    return string
 
 
-def add_filetest(TestClass, path):
+def add_filetest(testclass, path):
+    """Add test that imports the given path and runs its test() function
+
+    TODO: make work for subdirectories, using os.chdir"""
     path = path.strip()
     print "adding test for", repr(path)
 
@@ -35,7 +37,7 @@ def add_filetest(TestClass, path):
             self.fail("file '%s' had no `test` function." % path)
         mod.test()
 
-    setattr(TestClass, "test_"+clean(path), test_fn)
+    setattr(testclass, "test_"+clean(path), test_fn)
 
 
 SOLVERS = settings["installed_solvers"]
@@ -45,14 +47,15 @@ def newtest_fn(name, solver, import_dict, path):
     "Doubly nested callbacks to run the test with `getattr(self, name)()`"
     return new_test(name, solver, import_dict, path,
                     testfn=(lambda name, import_dict, path:
-                            lambda self: getattr(self, name)()))
+                            lambda self: getattr(self, name)()))  # pylint:disable=undefined-variable
 
 
 def run(filename="TESTS", xmloutput=False):
+    "Parse and run paths from a given file for each solver"
     with open(filename, "r") as f:
         for path in f:
             add_filetest(TestFiles, path)
-    TESTS = generate_example_tests("", [TestFiles], SOLVERS,
+    tests = generate_example_tests("", [TestFiles], SOLVERS,
                                    newtest_fn=newtest_fn)
-    from gpkit.tests.run_tests import run
-    run(tests=TESTS, unitless=False, xmloutput=xmloutput)
+    from gpkit.tests.run_tests import run as run_
+    run_(tests=tests, unitless=False, xmloutput=xmloutput)

--- a/gpkit/tests/from_paths.py
+++ b/gpkit/tests/from_paths.py
@@ -48,9 +48,6 @@ def add_filetest(testclass, path):
     setattr(testclass, "test_"+clean(path), test_fn)
 
 
-SOLVERS = settings["installed_solvers"]
-
-
 def newtest_fn(name, solver, import_dict, path):
     "Doubly nested callbacks to run the test with `getattr(self, name)()`"
     return new_test(name, solver, import_dict, path,
@@ -58,12 +55,14 @@ def newtest_fn(name, solver, import_dict, path):
                             lambda self: getattr(self, name)()))  # pylint:disable=undefined-variable
 
 
-def run(filename="TESTS", xmloutput=False):
+def run(filename="TESTS", xmloutput=False, skipsolvers=None):
     "Parse and run paths from a given file for each solver"
     with open(filename, "r") as f:
         for path in f:
             add_filetest(TestFiles, path)
-    tests = generate_example_tests("", [TestFiles], SOLVERS,
+    solvers = [s for s in settings["installed_solvers"]
+               if not skipsolvers or s not in skipsolvers]
+    tests = generate_example_tests("", [TestFiles], solvers,
                                    newtest_fn=newtest_fn)
     from gpkit.tests.run_tests import run as run_
     run_(tests=tests, unitless=False, xmloutput=xmloutput)

--- a/gpkit/tests/helpers.py
+++ b/gpkit/tests/helpers.py
@@ -30,22 +30,25 @@ def generate_example_tests(path, testclasses, solvers=None, newtest_fn=None):
     for testclass in testclasses:
         if os.path.isdir(path):
             sys.path.insert(0, path)
-            for fn in dir(testclass):
-                if fn[:5] == "test_":
-                    name = fn[5:]
-                    old_test = getattr(testclass, fn)
-                    setattr(testclass, name, old_test)  # move to a non-test fn
-                    delattr(testclass, fn)  # delete the old old_test
-                    for solver in solvers:
-                        new_name = "test_%s_%s" % (name, solver)
-                        new_fn = newtest_fn(name, solver, import_dict, path)
-                        setattr(testclass, new_name, new_fn)
-            tests.append(testclass)
+        for fn in dir(testclass):
+            if fn[:5] == "test_":
+                name = fn[5:]
+                old_test = getattr(testclass, fn)
+                setattr(testclass, name, old_test)  # move to a non-test fn
+                delattr(testclass, fn)  # delete the old old_test
+                for solver in solvers:
+                    new_name = "test_%s_%s" % (name, solver)
+                    new_fn = newtest_fn(name, solver, import_dict, path)
+                    setattr(testclass, new_name, new_fn)
+        tests.append(testclass)
     return tests
 
 
-def new_test(name, solver, import_dict, path):
+def new_test(name, solver, import_dict, path, testfn=None):
     """logged_example_testcase with a NewDefaultSolver"""
+    if testfn is None:
+        testfn = logged_example_testcase
+
     def test(self):
         # pylint: disable=missing-docstring
         # No docstring because it'd be uselessly the same for each example
@@ -56,7 +59,7 @@ def new_test(name, solver, import_dict, path):
             del gpkit.MODELNUM_LOOKUP[key]
 
         with NewDefaultSolver(solver):
-            logged_example_testcase(name, import_dict, path)(self)
+            testfn(name, import_dict, path)(self)
 
         # check all other global state besides MODELNUM_LOOKUP
         #   is falsy (which should mean blank)

--- a/gpkit/tests/run_tests.py
+++ b/gpkit/tests/run_tests.py
@@ -43,7 +43,7 @@ def import_tests():
     return tests
 
 
-def run(xmloutput=False):
+def run(xmloutput=False, tests=None, unitless=True):
     """Run all gpkit unit tests.
 
     Arguments
@@ -51,20 +51,22 @@ def run(xmloutput=False):
     xmloutput: bool
         If true, generate xml output files for continuous integration
     """
-    tests = import_tests()
+    if tests is None:
+        tests = import_tests()
     if xmloutput:
         run_tests(tests, xmloutput='test_reports')
     else:
         run_tests(tests)
-    print("\n##################################"
-          "####################################")
-    print("Running with units disabled:")
-    gpkit.disable_units()
-    if xmloutput:
-        run_tests(tests, xmloutput='test_reports_nounits')
-    else:
-        run_tests(tests, verbosity=1)
-    gpkit.enable_units()
+    if unitless:
+        print("\n##################################"
+              "####################################")
+        print("Running with units disabled:")
+        gpkit.disable_units()
+        if xmloutput:
+            run_tests(tests, xmloutput='test_reports_nounits')
+        else:
+            run_tests(tests, verbosity=1)
+        gpkit.enable_units()
 
 if __name__ == '__main__':
     run()

--- a/gpkit/tests/test_repo.py
+++ b/gpkit/tests/test_repo.py
@@ -9,16 +9,18 @@ from collections import defaultdict
 def test_repos(xmloutput=False):
     "From gpkit-models gets the list of external repos to test, and tests."
     git_clone("gpkit-models")
-    pip_install("gpkit-models", local=True)
-    os.chdir("gpkit-models")
-    repos = [line.strip() for line in open("EXTERNALTESTS", "r")]
-    os.chdir("..")
+    repos_list_filename = "gpkit-models"+os.sep+"EXTERNALTESTS"
+    repos = [line.strip() for line in open(repos_list_filename, "r")]
     for repo in repos:
         git_clone(repo)
         if os.path.isfile("repo"+os.sep+"setup.py"):
             pip_install(repo, local=True)
         os.chdir(repo)
         settings = get_settings()
+        print
+        print "SETTINGS"
+        print settings
+        print
 
         # install gpkit-models
         if "gpkit-models branch" in settings:

--- a/gpkit/tests/test_repo.py
+++ b/gpkit/tests/test_repo.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from gpkit.tests.from_paths import run
 
 
-def test_repos(repos=["d8", "gas_solar_trade"]):
+def test_repos(repos=["d8", "gas_solar_trade"], xmloutput=False):
     gpkit_models = False
     for repo in repos:
         git_clone(repo, branch="test_prep")
@@ -39,7 +39,8 @@ def test_repos(repos=["d8", "gas_solar_trade"]):
 
         # TODO: xmloutput=True
         testpy = ("from gpkit.tests.from_paths import run;"
-                  "run(skipsolvers=%s)" % repr(settings["skipsolvers"]))
+                  "run(xmloutput=%s, skipsolvers=%s)"
+                  % (xmloutput, repr(settings["skipsolvers"])))
         subprocess.call(["python", "-c", testpy])
         os.chdir("..")
 

--- a/gpkit/tests/test_repo.py
+++ b/gpkit/tests/test_repo.py
@@ -1,0 +1,89 @@
+import os
+import sys
+import subprocess
+from time import sleep
+from collections import defaultdict
+
+from gpkit.tests.from_paths import run
+
+
+def test_repos(repos=["d8", "gas_solar_trade"]):
+    gpkit_models = False
+    for repo in repos:
+        git_clone(repo, branch="test_prep")
+        if os.path.isfile("repo"+os.sep+"setup.py"):
+            pip_install(repo, local=True)
+        os.chdir(repo)
+        settings = get_settings()
+
+        # install gpkit-models
+        if "gpkit-models branch" in settings:
+            branch = settings["gpkit-models branch"]
+            os.chdir("..")
+            if not os.path.isdir("gpkit-models"):
+                git_clone("gpkit-models", branch=branch)
+                pip_install("gpkit-models", local=True)
+            else:
+                os.chdir("gpkit-models")
+                call_and_retry(["git", "fetch", "--depth", "1", "origin",
+                                branch])
+                subprocess.call(["git", "checkout", "FETCH_HEAD"])
+                os.chdir("..")
+            os.chdir(repo)
+
+        # install other dependencies
+        if settings["pip install"]:
+            for package in settings["pip install"].split(","):
+                package = package.strip()
+                pip_install(package)
+
+        # TODO: xmloutput=True
+        testpy = ("from gpkit.tests.from_paths import run;"
+                  "run(skipsolvers=%s)" % repr(settings["skipsolvers"]))
+        subprocess.call(["python", "-c", testpy])
+        os.chdir("..")
+
+
+def get_settings():
+    settings = defaultdict(str)
+    if os.path.isfile("TESTCONFIG"):
+        with open("TESTCONFIG", "r") as f:
+            for line in f:
+                if len(line.strip().split(" : ")) > 1:
+                    key, value = line.strip().split(" : ")
+                    settings[key] = value
+    return settings
+
+
+def git_clone(repo, branch):
+    cmd = ["git", "clone", "--depth", "1"]
+    cmd += ["-b", branch]
+    cmd += ["https://github.com/hoburg/%s.git" % repo]
+    call_and_retry(cmd)
+
+
+def pip_install(package, local=False):
+    if sys.platform == "win32":
+        cmd = ["pip"]
+    else:
+        cmd = ["python", os.environ["PIP"]]
+    subprocess.call(cmd + ["uninstall", package])
+    cmd += ["install"]
+    if local:
+        cmd += ["-e"]
+    else:
+        cmd += ["--upgrade"]
+    cmd += [package]
+    call_and_retry(cmd)
+
+
+def call_and_retry(cmd, max_iterations=5, delay=5):
+    iterations = 0
+    return_code = None
+    print "calling", cmd
+    while return_code != 0 and iterations < max_iterations:
+        iterations += 1
+        print "  attempt", iterations
+        return_code = subprocess.call(cmd)
+        sleep(delay)
+    return return_code

--- a/gpkit/tests/test_repo.py
+++ b/gpkit/tests/test_repo.py
@@ -1,16 +1,20 @@
+"Implements tests for all external repositories."
 import os
 import sys
 import subprocess
 from time import sleep
 from collections import defaultdict
 
-from gpkit.tests.from_paths import run
 
-
-def test_repos(repos=["d8", "gas_solar_trade"], xmloutput=False):
-    gpkit_models = False
+def test_repos(xmloutput=False):
+    "From gpkit-models gets the list of external repos to test, and tests."
+    git_clone("gpkit-models")
+    pip_install("gpkit-models", local=True)
+    os.chdir("gpkit-models")
+    repos = [line.strip() for line in open("EXTERNALTESTS", "r")]
+    os.chdir("..")
     for repo in repos:
-        git_clone(repo, branch="test_prep")
+        git_clone(repo)
         if os.path.isfile("repo"+os.sep+"setup.py"):
             pip_install(repo, local=True)
         os.chdir(repo)
@@ -20,15 +24,12 @@ def test_repos(repos=["d8", "gas_solar_trade"], xmloutput=False):
         if "gpkit-models branch" in settings:
             branch = settings["gpkit-models branch"]
             os.chdir("..")
-            if not os.path.isdir("gpkit-models"):
-                git_clone("gpkit-models", branch=branch)
-                pip_install("gpkit-models", local=True)
-            else:
-                os.chdir("gpkit-models")
-                call_and_retry(["git", "fetch", "--depth", "1", "origin",
-                                branch])
-                subprocess.call(["git", "checkout", "FETCH_HEAD"])
-                os.chdir("..")
+            os.chdir("gpkit-models")
+            call_and_retry(["git", "fetch", "--depth", "1", "origin",
+                            branch])
+            subprocess.call(["git", "checkout", "FETCH_HEAD"])
+            os.chdir("..")
+            pip_install("gpkit-models", local=True)
             os.chdir(repo)
 
         # install other dependencies
@@ -46,6 +47,7 @@ def test_repos(repos=["d8", "gas_solar_trade"], xmloutput=False):
 
 
 def get_settings():
+    "Gets settings from a TESTCONFIG file"
     settings = defaultdict(str)
     if os.path.isfile("TESTCONFIG"):
         with open("TESTCONFIG", "r") as f:
@@ -56,7 +58,8 @@ def get_settings():
     return settings
 
 
-def git_clone(repo, branch):
+def git_clone(repo, branch="master"):
+    "Tries several times to clone a given repository"
     cmd = ["git", "clone", "--depth", "1"]
     cmd += ["-b", branch]
     cmd += ["https://github.com/hoburg/%s.git" % repo]
@@ -64,11 +67,13 @@ def git_clone(repo, branch):
 
 
 def pip_install(package, local=False):
+    "Tries several times to install a pip package"
     if sys.platform == "win32":
         cmd = ["pip"]
     else:
         cmd = ["python", os.environ["PIP"]]
-    subprocess.call(cmd + ["uninstall", package])
+    if local:  # remove any other local packages of the same name...
+        subprocess.call(cmd + ["uninstall", package])
     cmd += ["install"]
     if local:
         cmd += ["-e"]
@@ -79,6 +84,7 @@ def pip_install(package, local=False):
 
 
 def call_and_retry(cmd, max_iterations=5, delay=5):
+    "Tries max_iterations times (waiting d each time) to run a command"
     iterations = 0
     return_code = None
     print "calling", cmd


### PR DESCRIPTION
@galbramc, the script here seems to work for testing external repositories; just run `python -c "from gpkit.tests.from_paths import run; run()` while in the root of the appropriate repository. At group meeting tomorrow I'll get people to add `TESTS` files to their repositories; where do you want me to stick the `EXTERNAL_REPOSITORIES` file listing these? Perhaps in gpkit-models?