### PR TITLE
Lint for program interfaces

### DIFF
--- a/gpkit/constraints/geometric_program.py
+++ b/gpkit/constraints/geometric_program.py
@@ -189,16 +189,14 @@ class GeometricProgram(CostedConstraintSet, NomialData):
             print("result packing took %.2g%% of solve time" %
                   ((time() - tic) / soltime * 100))
             tic = time()
-
-        if warn_on_check:
-            try:
-                self.check_solution(self.result["cost"], solver_out['primal'],
-                                    nu=solver_out["nu"], la=solver_out["la"])
-            except RuntimeWarning, e:
-                print "Solution check warning", str(e)
-        else:
+        try:
             self.check_solution(self.result["cost"], solver_out['primal'],
                                 nu=solver_out["nu"], la=solver_out["la"])
+        except RuntimeWarning as e:
+            if warn_on_check:
+                print "Solution check warning:", str(e)
+            else:
+                raise e
         if verbosity > 1:
             print("solution checking took %.2g%% of solve time" %
                   ((time() - tic) / soltime * 100))

--- a/gpkit/constraints/geometric_program.py
+++ b/gpkit/constraints/geometric_program.py
@@ -88,8 +88,9 @@ class GeometricProgram(CostedConstraintSet, NomialData):
             for var, bound in sorted(self.missingbounds.items()):
                 print("%s has no %s bound" % (var, bound))
 
-    # pylint: disable=too-many-statements
-    def solve(self, solver=None, verbosity=1, *args, **kwargs):
+    # pylint: disable=too-many-statements, too-many-locals
+    def solve(self, solver=None, verbosity=1, warn_on_check=False,
+              *args, **kwargs):
         """Solves a GeometricProgram and returns the solution.
 
         Arguments
@@ -189,8 +190,15 @@ class GeometricProgram(CostedConstraintSet, NomialData):
                   ((time() - tic) / soltime * 100))
             tic = time()
 
-        self.check_solution(self.result["cost"], solver_out['primal'],
-                            nu=solver_out["nu"], la=solver_out["la"])
+        if warn_on_check:
+            try:
+                self.check_solution(self.result["cost"], solver_out['primal'],
+                                    nu=solver_out["nu"], la=solver_out["la"])
+            except RuntimeWarning, e:
+                print "Solution check warning", str(e)
+        else:
+            self.check_solution(self.result["cost"], solver_out['primal'],
+                                nu=solver_out["nu"], la=solver_out["la"])
         if verbosity > 1:
             print("solution checking took %.2g%% of solve time" %
                   ((time() - tic) / soltime * 100))

--- a/gpkit/constraints/signomial_program.py
+++ b/gpkit/constraints/signomial_program.py
@@ -65,7 +65,7 @@ class SignomialProgram(CostedConstraintSet):
         self.result = None
 
     # pylint: disable=too-many-locals
-    def localsolve(self, solver=None, verbosity=1, x0=None, rel_tol=1e-4,
+    def localsolve(self, solver=None, verbosity=1, x0=None, reltol=1e-4,
                    iteration_limit=50, **kwargs):
         """Locally solves a SignomialProgram and returns the solution.
 
@@ -81,7 +81,7 @@ class SignomialProgram(CostedConstraintSet):
             if greater than 1, prints solver name and time for each GP.
         x0 : dict (optional)
             Initial location to approximate signomials about.
-        rel_tol : float
+        reltol : float
             Iteration ends when this is greater than the distance between two
             consecutive solve's objective values.
         iteration_limit : int
@@ -101,7 +101,7 @@ class SignomialProgram(CostedConstraintSet):
         self.gps = []  # NOTE: SIDE EFFECTS
         slackvar = Variable()
         prevcost, cost, rel_improvement = None, None, None
-        while rel_improvement is None or rel_improvement > rel_tol:
+        while rel_improvement is None or rel_improvement > reltol:
             if len(self.gps) > iteration_limit:
                 raise RuntimeWarning("""problem unsolved after %s iterations.
 

--- a/gpkit/tests/test_repo.py
+++ b/gpkit/tests/test_repo.py
@@ -97,8 +97,6 @@ def pip_install(package, local=False):
     cmd += ["install"]
     if local:
         cmd += ["--no-cache-dir", "--no-deps", "-e"]
-    else:
-        cmd += ["--upgrade"]
     cmd += [package]
     call_and_retry(cmd)
 


### PR DESCRIPTION
Using the more-standard `reltol` argument for SPs, and allowing users to just warn of invalid solutions (ocassionally useful for debugging, [here](https://github.com/hoburg/d8/issues/17#issuecomment-274136575) and in robustness development)

@whoburg, ready for review