### PR TITLE
allow appending to a constraintset

### DIFF
--- a/gpkit/constraints/set.py
+++ b/gpkit/constraints/set.py
@@ -96,8 +96,6 @@ class ConstraintSet(list):
         return variables
 
     def __setitem__(self, key, value):
-        if not isinstance(value, ConstraintSet):
-            value = ConstraintSet(value)
         self.substitutions.update(value.substitutions)
         list.__setitem__(self, key, value)
         self.reset_varkeys()

--- a/gpkit/constraints/set.py
+++ b/gpkit/constraints/set.py
@@ -96,14 +96,16 @@ class ConstraintSet(list):
         return variables
 
     def __setitem__(self, key, value):
-        if hasattr(value, "substitutions"):
-            self.substitutions.update(value.substitutions)
+        if not isinstance(value, ConstraintSet):
+            value = ConstraintSet(value)
+        self.substitutions.update(value.substitutions)
         list.__setitem__(self, key, value)
         self.reset_varkeys()
 
     def append(self, value):
-        if hasattr(value, "substitutions"):
-            self.substitutions.update(value.substitutions)
+        if not isinstance(value, ConstraintSet):
+            value = ConstraintSet(value)
+        self.substitutions.update(value.substitutions)
         list.append(self, value)
         self.reset_varkeys()
 

--- a/gpkit/constraints/set.py
+++ b/gpkit/constraints/set.py
@@ -101,6 +101,12 @@ class ConstraintSet(list):
         list.__setitem__(self, key, value)
         self.reset_varkeys()
 
+    def append(self, value):
+        if hasattr(value, "substitutions"):
+            self.substitutions.update(value.substitutions)
+        list.append(self, value)
+        self.reset_varkeys()
+
     __str__ = _str
     __repr__ = _repr
     _repr_latex_ = _repr_latex_

--- a/gpkit/constraints/set.py
+++ b/gpkit/constraints/set.py
@@ -101,7 +101,7 @@ class ConstraintSet(list):
         self.reset_varkeys()
 
     def append(self, value):
-        if not isinstance(value, ConstraintSet):
+        if hasattr(value, "__iter__") and not isinstance(value, ConstraintSet):
             value = ConstraintSet(value)
         self.substitutions.update(value.substitutions)
         list.append(self, value)


### PR DESCRIPTION
example code from @mjburton11 

```python
" wing.py "
import numpy as np
from gpkit import Variable, Model, SignomialsEnabled, ConstraintSet
from gpkitmodels.GP.aircraft.wing.wing import Wing as WingGP
from gpkit import Variable, Model, Vectorize, SignomialsEnabled

# pylint: disable=attribute-defined-outside-init, invalid-name


def Wingtest(N=5, lam=0.5, spar="CapSpar", hollow=False):
    wing = WingGP(N=N, lam=lam, spar=spar, hollow=hollow)
    mw = Variable("m_w", "-", "span wise effectiveness")

    with SignomialsEnabled():
        constraints = [mw*(1 + 2/wing["AR"]) >= 2*np.pi]

    wing.append(constraints)
    return wing

w = Wingtest()
print w["m_w"]
```