### PR TITLE
Adds the unit of g's

### DIFF
--- a/gpkit/__init__.py
+++ b/gpkit/__init__.py
@@ -66,6 +66,7 @@ def enable_units(path=None):
             UNIT_REGISTRY.load_definitions(os_sep.join([path, "usd_cpi.txt"]))
             # next line patches https://github.com/hgrecco/pint/issues/366
             UNIT_REGISTRY.define("nautical_mile = 1852 m = nmi")
+            UNIT_REGISTRY.define("gravitational_accel = 9.81 m/s**2 = G")
 
         ureg = UNIT_REGISTRY
         DimensionalityError = pint.DimensionalityError

--- a/gpkit/__init__.py
+++ b/gpkit/__init__.py
@@ -66,7 +66,7 @@ def enable_units(path=None):
             UNIT_REGISTRY.load_definitions(os_sep.join([path, "usd_cpi.txt"]))
             # next line patches https://github.com/hgrecco/pint/issues/366
             UNIT_REGISTRY.define("nautical_mile = 1852 m = nmi")
-            UNIT_REGISTRY.define("gravitational_accel = 9.81 m/s**2 = G")
+            UNIT_REGISTRY.define("gravitational_accel = 9.80665 m/s**2 = gs")
 
         ureg = UNIT_REGISTRY
         DimensionalityError = pint.DimensionalityError


### PR DESCRIPTION
Adding units of g's (well, actually, G's) so that people can express acceleration in terms of [earth's] gravitational acceleration.

`g` obviously means grams primarily, so opting for uppercase `G` as the next best option.

I've run this past @bqpd. What do you think @whoburg?